### PR TITLE
Release v2.4.0 - SMTPS Support

### DIFF
--- a/ChangeLog/2.4.0.md
+++ b/ChangeLog/2.4.0.md
@@ -1,0 +1,124 @@
+# Change Log: Version 2.4.0
+
+**Release Date:** 2026-01-30
+
+This release adds SMTPS (implicit TLS) support, enabling connections on port 465 where TLS encryption is established immediately after TCP connection.
+
+## Key Highlights
+
+- **New SMTPS support** - Connect using implicit TLS on port 465
+- **New `-smtps` flag** - Enable SMTPS mode for all actions
+- **Smart port default** - Automatically uses port 465 when `-smtps` is specified
+- **Environment variable** - `SMTPSMTPS` for configuration via environment
+
+---
+
+## New Features
+
+### 1. SMTPS (Implicit TLS) Support
+
+**What is SMTPS?**
+SMTPS performs TLS handshake immediately after TCP connection, unlike STARTTLS where encryption happens after initial SMTP commands. This is the standard method for port 465.
+
+**New `-smtps` flag:**
+```bash
+# Test SMTPS connection (port defaults to 465)
+smtptool -action testconnect -host smtp.gmail.com -smtps
+
+# Test SMTPS TLS details
+smtptool -action teststarttls -host smtp.gmail.com -port 465 -smtps
+
+# Authenticate over SMTPS
+smtptool -action testauth -host smtp.gmail.com -smtps -username user@gmail.com -password secret
+
+# Send mail over SMTPS
+smtptool -action sendmail -host smtp.gmail.com -smtps -username user@gmail.com -password secret -from sender@gmail.com -to recipient@example.com
+
+# SMTPS with TLS 1.3 and skip certificate verification
+smtptool -action teststarttls -host mail.example.com -port 465 -smtps -tlsversion 1.3 -skipverify
+```
+
+**Environment variable support:**
+```bash
+export SMTPSMTPS=true
+smtptool -action testconnect -host smtp.gmail.com
+```
+
+**Smart port default:**
+When `-smtps` is used without `-port`, the port automatically defaults to 465 (instead of 25).
+
+**Mutual exclusion:**
+The `-smtps` and `-starttls` flags cannot be used together, as they represent different TLS modes.
+
+---
+
+## Implementation Details
+
+### Files Modified
+
+- `cmd/smtptool/config.go`
+  - Added `SMTPS bool` field to Config struct
+  - Added `-smtps` flag definition
+  - Added `SMTPSMTPS` environment variable support
+  - Added mutual exclusion validation with `-starttls`
+  - Added smart port default (465 when `-smtps` is set)
+  - Added SMTPS examples to help text
+
+- `cmd/smtptool/smtp_client.go`
+  - Added `tlsState *tls.ConnectionState` field
+  - Modified `Connect()` to perform immediate TLS handshake for SMTPS
+  - Added `IsEncrypted()` helper method
+  - Added `GetTLSState()` helper method
+  - Updated `StartTLS()` to store TLS state
+
+- `cmd/smtptool/teststarttls.go`
+  - Updated output messages for SMTPS mode
+  - Skip STARTTLS capability check for SMTPS
+  - Use stored TLS state for SMTPS connections
+
+- `cmd/smtptool/testauth.go`
+  - Skip STARTTLS upgrade when SMTPS is enabled
+  - Display TLS info from stored state for SMTPS
+
+- `cmd/smtptool/sendmail.go`
+  - Skip STARTTLS upgrade when SMTPS is enabled
+  - Display TLS info from stored state for SMTPS
+
+- `cmd/smtptool/testconnect.go`
+  - Updated output messages for SMTPS mode
+
+---
+
+## Testing
+
+### Automated Testing
+- Build successful
+- All existing unit tests pass
+
+### Manual Verification
+- Tested against Gmail SMTPS: `smtp.gmail.com:465`
+- Verified `-smtps` and `-starttls` mutual exclusion error
+- Verified smart port defaulting (port changes to 465)
+- Verified TLS version forcing works with SMTPS
+- Verified `-skipverify` works with SMTPS
+
+---
+
+## Upgrade Notes
+
+This is a feature addition with no breaking changes. Existing functionality remains unchanged.
+
+---
+
+## Contributors
+
+- Claude Opus 4.5 (AI Assistant)
+- Project Maintainer: ziembor
+
+---
+
+## Links
+
+- **Repository**: https://github.com/ziembor/gomailtesttool
+- **Release Tag**: v2.4.0
+- **Previous Release**: v2.3.3 (2026-01-25)

--- a/internal/common/version/version.go
+++ b/internal/common/version/version.go
@@ -8,7 +8,7 @@ package version
 // 1. Change the Version constant below
 // 2. Create a changelog entry in ChangeLog/{version}.md
 // 3. Commit with message: "Bump version to {version}"
-const Version = "2.3.3"
+const Version = "2.4.0"
 
 // Get returns the current version string.
 // This is a convenience function for accessing the Version constant.


### PR DESCRIPTION
## Summary

- Adds SMTPS (implicit TLS) support for port 465 connections
- New `-smtps` flag enables implicit TLS mode for all actions
- Smart port default: automatically uses port 465 when `-smtps` is specified
- Environment variable support via `SMTPSMTPS`
- Bumps version to 2.4.0

## Test plan

- [x] Build successful
- [x] All existing unit tests pass
- [x] Verified `-smtps` and `-starttls` mutual exclusion
- [x] Verified smart port defaulting to 465
- [x] Verified TLS version forcing works with SMTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)