### PR TITLE
Release v2.5.0 - XOAUTH2 Support

### DIFF
--- a/ChangeLog/2.5.0.md
+++ b/ChangeLog/2.5.0.md
@@ -1,0 +1,119 @@
+# Change Log: Version 2.5.0
+
+**Release Date:** 2026-01-30
+
+This release adds XOAUTH2 authentication support for OAuth2-based authentication with modern email providers like Gmail and Microsoft 365.
+
+## Key Highlights
+
+- **XOAUTH2 authentication** - OAuth2 bearer token authentication support
+- **New `-accesstoken` flag** - Pass OAuth2 access tokens for authentication
+- **Auto-selection** - Prefers XOAUTH2 when access token is provided
+- **Environment variable** - `SMTPACCESSTOKEN` for secure token configuration
+
+---
+
+## New Features
+
+### XOAUTH2 Authentication Support
+
+XOAUTH2 is a SASL mechanism that uses OAuth 2.0 access tokens for authentication, commonly used by Gmail, Microsoft 365, and other modern email providers.
+
+**New `-accesstoken` flag:**
+```bash
+# Test XOAUTH2 authentication against Gmail
+smtptool -action testauth -host smtp.gmail.com -smtps \
+  -username user@gmail.com \
+  -accesstoken "ya29.a0AfH6SMB..."
+
+# Send mail with XOAUTH2 (Gmail)
+smtptool -action sendmail -host smtp.gmail.com -smtps \
+  -username user@gmail.com \
+  -accesstoken "ya29.a0AfH6SMB..." \
+  -from user@gmail.com -to recipient@example.com
+
+# Test XOAUTH2 against Microsoft 365
+smtptool -action testauth -host smtp.office365.com -port 587 \
+  -username user@company.com \
+  -accesstoken "eyJ0eXAiOiJKV1Qi..."
+
+# Force XOAUTH2 mechanism explicitly
+smtptool -action testauth -host smtp.gmail.com -smtps \
+  -username user@gmail.com \
+  -accesstoken "token..." \
+  -authmethod XOAUTH2
+```
+
+**Environment variable support:**
+```bash
+export SMTPACCESSTOKEN="ya29.a0AfH6SMB..."
+smtptool -action testauth -host smtp.gmail.com -smtps -username user@gmail.com
+```
+
+**Auto-selection behavior:**
+- When `-accesstoken` is provided, XOAUTH2 is preferred over other mechanisms
+- When only `-password` is provided, PLAIN/LOGIN/CRAM-MD5 are used as before
+
+---
+
+## Token Acquisition
+
+Users must obtain OAuth2 access tokens externally. Common methods:
+
+**Gmail:**
+1. Create Google Cloud project with Gmail API
+2. Use OAuth 2.0 Playground or gcloud CLI
+3. Scope: `https://mail.google.com/`
+
+**Microsoft 365:**
+1. Register app in Azure AD
+2. Use client credentials or device code flow
+3. Scope: `https://outlook.office365.com/.default`
+
+---
+
+## Implementation Details
+
+### Files Modified
+
+- `cmd/smtptool/config.go`
+  - Added `AccessToken` field to Config struct
+  - Added `-accesstoken` flag definition
+  - Added `SMTPACCESSTOKEN` environment variable support
+  - Updated `-authmethod` to include XOAUTH2
+  - Added validation for XOAUTH2 requirements
+
+- `cmd/smtptool/smtp_client.go`
+  - Added `xoauth2Auth` struct implementing `smtp.Auth` interface
+  - Updated `selectAuthMechanism()` to prefer XOAUTH2 when token provided
+  - Updated `Auth()` method signature to accept `accessToken` parameter
+
+- `cmd/smtptool/testauth.go`
+  - Updated to pass `accessToken` to Auth() method
+
+- `cmd/smtptool/sendmail.go`
+  - Updated to support XOAUTH2 authentication
+
+- `cmd/smtptool/utils.go`
+  - Added `maskAccessToken()` helper for safe logging
+
+---
+
+## Upgrade Notes
+
+This is a feature addition with no breaking changes. Existing authentication methods (PLAIN, LOGIN, CRAM-MD5) continue to work as before.
+
+---
+
+## Contributors
+
+- Claude Opus 4.5 (AI Assistant)
+- Project Maintainer: ziembor
+
+---
+
+## Links
+
+- **Repository**: https://github.com/ziembor/gomailtesttool
+- **Release Tag**: v2.5.0
+- **Previous Release**: v2.4.0 (2026-01-30)

--- a/internal/common/version/version.go
+++ b/internal/common/version/version.go
@@ -8,7 +8,7 @@ package version
 // 1. Change the Version constant below
 // 2. Create a changelog entry in ChangeLog/{version}.md
 // 3. Commit with message: "Bump version to {version}"
-const Version = "2.4.0"
+const Version = "2.5.0"
 
 // Get returns the current version string.
 // This is a convenience function for accessing the Version constant.


### PR DESCRIPTION
## Summary

- Adds XOAUTH2 (OAuth2 bearer token) authentication support
- New `-accesstoken` flag for OAuth2 tokens
- Environment variable support via `SMTPACCESSTOKEN`
- Auto-selects XOAUTH2 when access token provided
- Bumps version to 2.5.0

## Test plan

- [x] Build successful
- [x] All existing unit tests pass
- [x] XOAUTH2 tested against Gmail SMTPS
- [x] Regular password auth still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)