### PR TITLE
Release 2.7.0: Add connection address override to all mail tools

### DIFF
--- a/ChangeLog/2.6.19.md
+++ b/ChangeLog/2.6.19.md
@@ -1,0 +1,53 @@
+# Version 2.6.19
+
+## Changes
+
+### SMTP Tool Enhancement
+
+Added connection address override functionality to enable testing specific backend nodes behind load balancers while maintaining proper TLS validation.
+
+**Added:**
+- `--address` CLI flag to specify connection override address (IP or hostname)
+- `SMTPADDRESS` environment variable support
+- `ConnectAddress` field in Config struct
+
+**Features:**
+- Connect to a specific IP address or hostname while using different hostname for SNI
+- Proper IPv6 address support using `net.JoinHostPort()`
+- Certificate verification uses original hostname (configurable with `--skip-verify`)
+- CSV logging includes new `Connect_Address` column
+- Console output indicates when connection override is active
+
+**Updated Files:**
+- `cmd/smtptool/config.go` - Configuration and validation
+- `cmd/smtptool/smtp_client.go` - Connection logic with IPv6 support
+- `cmd/smtptool/testconnect.go` - Console output and CSV logging
+- `cmd/smtptool/teststarttls.go` - Console output and CSV logging
+- `cmd/smtptool/testauth.go` - Console output and CSV logging
+- `cmd/smtptool/sendmail.go` - Console output and CSV logging
+
+### Use Cases
+
+- Test specific backend SMTP server nodes behind load balancers
+- Connect to IP address while verifying certificate against hostname
+- Direct connection testing for troubleshooting
+
+### Usage Examples
+
+```bash
+# Connect to specific IP for load balancer testing
+smtptool --action testconnect --host mail.example.com --port 465 --address 192.168.1.10 --smtps
+
+# Test STARTTLS on specific backend node
+smtptool --action teststarttls --host smtp.example.com --port 587 --address 10.0.0.5
+
+# Use environment variable
+SMTPADDRESS=192.168.1.10 smtptool --action testconnect --host mail.example.com --port 587
+```
+
+### Benefits
+
+- Enables granular testing of individual nodes in load-balanced environments
+- Maintains security with proper SNI and certificate validation
+- Backward compatible - optional feature that doesn't affect existing usage
+- Supports both IPv4 and IPv6 addresses

--- a/ChangeLog/2.7.0.md
+++ b/ChangeLog/2.7.0.md
@@ -1,0 +1,11 @@
+# Version 2.7.0
+
+## Changes
+
+### Version Bump
+
+Minor version increment for upcoming feature development.
+
+**Notes:**
+- This is a development version
+- Changelog will be updated as features are implemented

--- a/IMAPTOOL_README.md
+++ b/IMAPTOOL_README.md
@@ -218,6 +218,7 @@ Folder listing completed successfully
 
 | Flag | Description | Environment Variable | Default |
 |------|-------------|---------------------|---------|
+| `-address` | Override IP/hostname for TCP connection (uses -host for SNI and cert verification) | `IMAPADDRESS` | - |
 | `-proxy` | Proxy URL | `IMAPPROXY` | - |
 | `-maxretries` | Maximum retry attempts | `IMAPMAXRETRIES` | 3 |
 | `-retrydelay` | Retry delay (milliseconds) | `IMAPRETRYDELAY` | 2000 |

--- a/JMAPTOOL_README.md
+++ b/JMAPTOOL_README.md
@@ -225,6 +225,12 @@ Mailbox listing completed successfully
 |------|-------------|---------------------|---------|
 | `-skipverify` | Skip TLS certificate verification | `JMAPSKIPVERIFY` | false |
 
+### Network Flags
+
+| Flag | Description | Environment Variable | Default |
+|------|-------------|---------------------|---------|
+| `-address` | Override IP/hostname for TCP connection (uses -host for SNI and cert verification) | `JMAPADDRESS` | - |
+
 ### Runtime Flags
 
 | Flag | Description | Environment Variable | Default |

--- a/POP3TOOL_README.md
+++ b/POP3TOOL_README.md
@@ -218,6 +218,7 @@ Message listing completed successfully
 
 | Flag | Description | Environment Variable | Default |
 |------|-------------|---------------------|---------|
+| `-address` | Override IP/hostname for TCP connection (uses -host for SNI and cert verification) | `POP3ADDRESS` | - |
 | `-proxy` | Proxy URL | `POP3PROXY` | - |
 | `-maxretries` | Maximum retry attempts | `POP3MAXRETRIES` | 3 |
 | `-retrydelay` | Retry delay (milliseconds) | `POP3RETRYDELAY` | 2000 |

--- a/SMTP_TOOL_README.md
+++ b/SMTP_TOOL_README.md
@@ -359,6 +359,12 @@ Sending message...
 | `-skipverify` | Skip TLS certificate verification (insecure) | `SMTPSKIPVERIFY` | false |
 | `-tlsversion` | Minimum TLS version: 1.2, 1.3 | `SMTPTLSVERSION` | 1.2 |
 
+### Network Flags
+
+| Flag | Description | Environment Variable | Default |
+|------|-------------|---------------------|---------|
+| `-address` | Override IP/hostname for TCP connection (uses -host for SNI and cert verification) | `SMTPADDRESS` | - |
+
 ### Runtime Flags
 
 | Flag | Description | Environment Variable | Default |

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -95,6 +95,7 @@ All tools use a consistent naming pattern: `{TOOL}{PARAMETER}` (no underscores)
 |-----------------|-------------|
 | `{PREFIX}HOST` | Server hostname |
 | `{PREFIX}PORT` | Server port |
+| `{PREFIX}ADDRESS` | Override connection address (IP or hostname for TCP connection) |
 | `{PREFIX}USERNAME` | Username for authentication |
 | `{PREFIX}PASSWORD` | Password for authentication |
 | `{PREFIX}ACCESSTOKEN` | OAuth2/Bearer access token |

--- a/cmd/imaptool/config.go
+++ b/cmd/imaptool/config.go
@@ -35,9 +35,10 @@ type Config struct {
 	TLSVersion string // TLS version to use: 1.2, 1.3
 
 	// Network configuration
-	ProxyURL   string
-	MaxRetries int
-	RetryDelay time.Duration
+	ConnectAddress string // Override address for TCP connection (IP or hostname)
+	ProxyURL       string
+	MaxRetries     int
+	RetryDelay     time.Duration
 
 	// Runtime configuration
 	VerboseMode  bool
@@ -90,7 +91,10 @@ func parseAndConfigureFlags() *Config {
 		fmt.Fprintf(flag.CommandLine.Output(), "Actions:\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  testconnect   - Test TCP connection and capabilities\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  testauth      - Test authentication (PLAIN, LOGIN, XOAUTH2)\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  listfolders   - List mailbox folders\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  listfolders   - List mailbox folders\n\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Connection Override Examples (for load balancer testing):\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action testconnect -host imap.example.com -port 993 -address 192.168.1.10 -imaps\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action testconnect -host imap.example.com -port 143 -address 10.0.0.5 -starttls\n", os.Args[0])
 	}
 
 	// Core flags
@@ -115,6 +119,7 @@ func parseAndConfigureFlags() *Config {
 	tlsVersion := flag.String("tlsversion", "1.2", "TLS version: 1.2, 1.3 (env: IMAPTLSVERSION)")
 
 	// Network configuration
+	connectAddress := flag.String("address", "", "Override IP address or hostname for TCP connection (uses -host for SNI and cert verification) (env: IMAPADDRESS)")
 	proxyURL := flag.String("proxy", "", "Proxy URL (env: IMAPPROXY)")
 	maxRetries := flag.Int("maxretries", 3, "Maximum retry attempts (env: IMAPMAXRETRIES)")
 	retryDelay := flag.Int("retrydelay", 2000, "Retry delay in milliseconds (env: IMAPRETRYDELAY)")
@@ -142,6 +147,7 @@ func parseAndConfigureFlags() *Config {
 	config.StartTLS = *startTLS
 	config.SkipVerify = *skipVerify
 	config.TLSVersion = *tlsVersion
+	config.ConnectAddress = *connectAddress
 	config.ProxyURL = *proxyURL
 	config.MaxRetries = *maxRetries
 	config.RetryDelay = time.Duration(*retryDelay) * time.Millisecond
@@ -203,6 +209,9 @@ func applyEnvOverrides(config *Config) {
 	}
 	if v := os.Getenv("IMAPTLSVERSION"); v != "" {
 		config.TLSVersion = v
+	}
+	if v := os.Getenv("IMAPADDRESS"); v != "" && config.ConnectAddress == "" {
+		config.ConnectAddress = v
 	}
 	if v := os.Getenv("IMAPPROXY"); v != "" && config.ProxyURL == "" {
 		config.ProxyURL = v
@@ -269,6 +278,13 @@ func validateConfiguration(config *Config) error {
 	}
 	if err := validation.ValidateHostname(config.Host); err != nil {
 		return fmt.Errorf("invalid host: %w", err)
+	}
+
+	// Validate connect address (if provided)
+	if config.ConnectAddress != "" {
+		if err := validation.ValidateHostname(config.ConnectAddress); err != nil {
+			return fmt.Errorf("invalid connect address: %w", err)
+		}
 	}
 
 	// Validate port

--- a/cmd/imaptool/imap_client.go
+++ b/cmd/imaptool/imap_client.go
@@ -56,7 +56,12 @@ func (c *IMAPClient) Connect(ctx context.Context) error {
 		}
 	}
 
-	address := fmt.Sprintf("%s:%d", c.host, c.port)
+	// Determine connection address (override or default to host)
+	connectHost := c.host
+	if c.config.ConnectAddress != "" {
+		connectHost = c.config.ConnectAddress
+	}
+	address := fmt.Sprintf("%s:%d", connectHost, c.port)
 
 	options := &imapclient.Options{
 		TLSConfig: &tls.Config{

--- a/cmd/jmaptool/config.go
+++ b/cmd/jmaptool/config.go
@@ -7,17 +7,19 @@ import (
 	"strconv"
 	"strings"
 
+	"msgraphtool/internal/common/validation"
 	"msgraphtool/internal/common/version"
 )
 
 // Config holds all configuration for jmaptool.
 type Config struct {
 	// Connection settings
-	Host        string
-	Port        int
-	Username    string
-	Password    string
-	AccessToken string
+	Host           string
+	Port           int
+	ConnectAddress string // Override address for TCP connection (IP or hostname)
+	Username       string
+	Password       string
+	AccessToken    string
 
 	// Action
 	Action string
@@ -55,6 +57,7 @@ func parseAndConfigureFlags() *Config {
 	flag.StringVar(&config.Action, "action", "", "Action to perform: testconnect, testauth, getmailboxes (env: JMAPACTION)")
 	flag.StringVar(&config.Host, "host", "", "JMAP server hostname (env: JMAPHOST)")
 	flag.IntVar(&config.Port, "port", 443, "JMAP server port (default: 443) (env: JMAPPORT)")
+	flag.StringVar(&config.ConnectAddress, "address", "", "Override IP address or hostname for TCP connection (uses -host for SNI and cert verification) (env: JMAPADDRESS)")
 	flag.StringVar(&config.Username, "username", "", "Username for authentication (env: JMAPUSERNAME)")
 	flag.StringVar(&config.Password, "password", "", "Password for authentication (env: JMAPPASSWORD)")
 	flag.StringVar(&config.AccessToken, "accesstoken", "", "Access token for Bearer authentication (env: JMAPACCESSTOKEN)")
@@ -78,6 +81,7 @@ func parseAndConfigureFlags() *Config {
 		fmt.Fprintf(os.Stderr, "\nEnvironment variables:\n")
 		fmt.Fprintf(os.Stderr, "  JMAPHOST        Server hostname\n")
 		fmt.Fprintf(os.Stderr, "  JMAPPORT        Server port\n")
+		fmt.Fprintf(os.Stderr, "  JMAPADDRESS     Override connection address\n")
 		fmt.Fprintf(os.Stderr, "  JMAPUSERNAME    Username\n")
 		fmt.Fprintf(os.Stderr, "  JMAPPASSWORD    Password\n")
 		fmt.Fprintf(os.Stderr, "  JMAPACCESSTOKEN Access token\n")
@@ -91,6 +95,9 @@ func parseAndConfigureFlags() *Config {
 		fmt.Fprintf(os.Stderr, "  jmaptool -action testconnect -host jmap.fastmail.com\n")
 		fmt.Fprintf(os.Stderr, "  jmaptool -action testauth -host jmap.fastmail.com -username user@example.com -accesstoken \"token\"\n")
 		fmt.Fprintf(os.Stderr, "  jmaptool -action getmailboxes -host jmap.fastmail.com -username user@example.com -accesstoken \"token\"\n")
+		fmt.Fprintf(os.Stderr, "\nConnection Override Examples (for load balancer testing):\n")
+		fmt.Fprintf(os.Stderr, "  jmaptool -action testconnect -host jmap.example.com -address 192.168.1.10\n")
+		fmt.Fprintf(os.Stderr, "  jmaptool -action testconnect -host jmap.example.com -port 8443 -address 10.0.0.5\n")
 	}
 
 	flag.Parse()
@@ -113,6 +120,11 @@ func parseAndConfigureFlags() *Config {
 			if port, err := strconv.Atoi(envPort); err == nil && port > 0 && port < 65536 {
 				config.Port = port
 			}
+		}
+	}
+	if !providedFlags["address"] {
+		if envAddress := os.Getenv("JMAPADDRESS"); envAddress != "" {
+			config.ConnectAddress = envAddress
 		}
 	}
 	if !providedFlags["username"] {
@@ -187,6 +199,13 @@ func validateConfiguration(config *Config) error {
 	// Validate port
 	if config.Port <= 0 || config.Port > 65535 {
 		return fmt.Errorf("invalid port: %d (must be 1-65535)", config.Port)
+	}
+
+	// Validate connect address (if provided)
+	if config.ConnectAddress != "" {
+		if err := validation.ValidateHostname(config.ConnectAddress); err != nil {
+			return fmt.Errorf("invalid connect address: %w", err)
+		}
 	}
 
 	// Validate auth method

--- a/cmd/jmaptool/jmap_client.go
+++ b/cmd/jmaptool/jmap_client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -25,8 +26,23 @@ type JMAPClient struct {
 func NewJMAPClient(config *Config) *JMAPClient {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
+			ServerName:         config.Host, // Use original host for SNI
 			InsecureSkipVerify: config.SkipVerify,
 		},
+	}
+
+	// If ConnectAddress is set, use custom dialer to override the connection address
+	if config.ConnectAddress != "" {
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// Replace host portion with override address, keep the port
+			_, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				// If no port in address, use original
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			}
+			overrideAddr := net.JoinHostPort(config.ConnectAddress, port)
+			return (&net.Dialer{}).DialContext(ctx, network, overrideAddr)
+		}
 	}
 
 	return &JMAPClient{

--- a/cmd/pop3tool/config.go
+++ b/cmd/pop3tool/config.go
@@ -38,9 +38,10 @@ type Config struct {
 	TLSVersion string // TLS version to use: 1.2, 1.3
 
 	// Network configuration
-	ProxyURL   string
-	MaxRetries int
-	RetryDelay time.Duration
+	ConnectAddress string // Override address for TCP connection (IP or hostname)
+	ProxyURL       string
+	MaxRetries     int
+	RetryDelay     time.Duration
 
 	// Runtime configuration
 	VerboseMode  bool
@@ -94,7 +95,10 @@ func parseAndConfigureFlags() *Config {
 		fmt.Fprintf(flag.CommandLine.Output(), "Actions:\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  testconnect   - Test TCP connection and capabilities\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  testauth      - Test authentication (USER/PASS, APOP, XOAUTH2)\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  listmail      - List messages in mailbox\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  listmail      - List messages in mailbox\n\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Connection Override Examples (for load balancer testing):\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action testconnect -host pop.example.com -port 995 -address 192.168.1.10 -pop3s\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action testconnect -host pop.example.com -port 110 -address 10.0.0.5 -starttls\n", os.Args[0])
 	}
 
 	// Core flags
@@ -122,6 +126,7 @@ func parseAndConfigureFlags() *Config {
 	tlsVersion := flag.String("tlsversion", "1.2", "TLS version: 1.2, 1.3 (env: POP3TLSVERSION)")
 
 	// Network configuration
+	connectAddress := flag.String("address", "", "Override IP address or hostname for TCP connection (uses -host for SNI and cert verification) (env: POP3ADDRESS)")
 	proxyURL := flag.String("proxy", "", "Proxy URL (env: POP3PROXY)")
 	maxRetries := flag.Int("maxretries", 3, "Maximum retry attempts (env: POP3MAXRETRIES)")
 	retryDelay := flag.Int("retrydelay", 2000, "Retry delay in milliseconds (env: POP3RETRYDELAY)")
@@ -150,6 +155,7 @@ func parseAndConfigureFlags() *Config {
 	config.StartTLS = *startTLS
 	config.SkipVerify = *skipVerify
 	config.TLSVersion = *tlsVersion
+	config.ConnectAddress = *connectAddress
 	config.ProxyURL = *proxyURL
 	config.MaxRetries = *maxRetries
 	config.RetryDelay = time.Duration(*retryDelay) * time.Millisecond
@@ -217,6 +223,9 @@ func applyEnvOverrides(config *Config) {
 	if v := os.Getenv("POP3TLSVERSION"); v != "" {
 		config.TLSVersion = v
 	}
+	if v := os.Getenv("POP3ADDRESS"); v != "" && config.ConnectAddress == "" {
+		config.ConnectAddress = v
+	}
 	if v := os.Getenv("POP3PROXY"); v != "" && config.ProxyURL == "" {
 		config.ProxyURL = v
 	}
@@ -282,6 +291,13 @@ func validateConfiguration(config *Config) error {
 	}
 	if err := validation.ValidateHostname(config.Host); err != nil {
 		return fmt.Errorf("invalid host: %w", err)
+	}
+
+	// Validate connect address (if provided)
+	if config.ConnectAddress != "" {
+		if err := validation.ValidateHostname(config.ConnectAddress); err != nil {
+			return fmt.Errorf("invalid connect address: %w", err)
+		}
 	}
 
 	// Validate port

--- a/cmd/pop3tool/pop3_client.go
+++ b/cmd/pop3tool/pop3_client.go
@@ -51,7 +51,12 @@ func (c *POP3Client) Connect(ctx context.Context) error {
 		}
 	}
 
-	address := fmt.Sprintf("%s:%d", c.host, c.port)
+	// Determine connection address (override or default to host)
+	connectHost := c.host
+	if c.config.ConnectAddress != "" {
+		connectHost = c.config.ConnectAddress
+	}
+	address := fmt.Sprintf("%s:%d", connectHost, c.port)
 
 	var conn net.Conn
 	var err error

--- a/cmd/smtptool/config.go
+++ b/cmd/smtptool/config.go
@@ -41,9 +41,10 @@ type Config struct {
 	TLSVersion string // TLS version to use (exact match): 1.2, 1.3
 
 	// Network configuration
-	ProxyURL   string
-	MaxRetries int
-	RetryDelay time.Duration
+	ConnectAddress string        // Override address for TCP connection (IP or hostname)
+	ProxyURL       string
+	MaxRetries     int
+	RetryDelay     time.Duration
 
 	// Runtime configuration
 	VerboseMode  bool
@@ -105,6 +106,9 @@ func parseAndConfigureFlags() *Config {
 		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action teststarttls -host smtp.example.com -port 587\n", os.Args[0])
 		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action testauth -host smtp.example.com -port 587 -username user@example.com -password secret\n", os.Args[0])
 		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action sendmail -host smtp.example.com -port 587 -username user@example.com -password secret -from sender@example.com -to recipient@example.com\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "\nConnection Override Examples (for load balancer testing):\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action testconnect -host mail.example.com -port 465 -address 192.168.1.10 -smtps\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action teststarttls -host smtp.example.com -port 587 -address 10.0.0.5\n", os.Args[0])
 		fmt.Fprintf(flag.CommandLine.Output(), "\nSMTPS Examples (implicit TLS on port 465):\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action testconnect -host smtp.gmail.com -port 465 -smtps\n", os.Args[0])
 		fmt.Fprintf(flag.CommandLine.Output(), "  %s -action teststarttls -host smtp.gmail.com -port 465 -smtps\n", os.Args[0])
@@ -132,6 +136,7 @@ func parseAndConfigureFlags() *Config {
 	smtps := flag.Bool("smtps", false, "Use SMTPS (implicit TLS), typically on port 465 (env: SMTPSMTPS)")
 	skipVerify := flag.Bool("skipverify", false, "Skip TLS certificate verification (insecure) (env: SMTPSKIPVERIFY)")
 	tlsVersion := flag.String("tlsversion", "1.2", "TLS version to use (exact): 1.2, 1.3 (env: SMTPTLSVERSION)")
+	connectAddress := flag.String("address", "", "Override IP address or hostname for TCP connection (uses --host for SNI and cert verification) (env: SMTPADDRESS)")
 	proxyURL := flag.String("proxy", "", "HTTP/HTTPS proxy URL (env: SMTPPROXY)")
 	maxRetries := flag.Int("maxretries", 3, "Maximum retry attempts (env: SMTPMAXRETRIES)")
 	retryDelay := flag.Int("retrydelay", 2000, "Retry delay in milliseconds (env: SMTPRETRYDELAY)")
@@ -163,6 +168,7 @@ func parseAndConfigureFlags() *Config {
 	config.SMTPS = *smtps
 	config.SkipVerify = *skipVerify
 	config.TLSVersion = *tlsVersion
+	config.ConnectAddress = *connectAddress
 	config.ProxyURL = *proxyURL
 	config.MaxRetries = *maxRetries
 	config.RetryDelay = time.Duration(*retryDelay) * time.Millisecond
@@ -232,6 +238,9 @@ func applyEnvironmentVariables(config *Config) {
 	if !config.SkipVerify {
 		config.SkipVerify = parseBoolEnv(os.Getenv("SMTPSKIPVERIFY"))
 	}
+	if config.ConnectAddress == "" {
+		config.ConnectAddress = os.Getenv("SMTPADDRESS")
+	}
 }
 
 // validateConfiguration validates the configuration.
@@ -287,6 +296,13 @@ func validateConfiguration(config *Config) error {
 	// Validate proxy URL (if provided)
 	if err := validation.ValidateProxyURL(config.ProxyURL); err != nil {
 		return fmt.Errorf("invalid proxy URL: %w", err)
+	}
+
+	// Validate connect address (if provided)
+	if config.ConnectAddress != "" {
+		if err := validation.ValidateHostname(config.ConnectAddress); err != nil {
+			return fmt.Errorf("invalid connect address: %w", err)
+		}
 	}
 
 	// Action-specific validation

--- a/cmd/smtptool/sendmail.go
+++ b/cmd/smtptool/sendmail.go
@@ -16,15 +16,23 @@ import (
 // sendMail performs end-to-end email sending test.
 func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slogLogger *slog.Logger) error {
 	if config.SMTPS {
-		fmt.Printf("Sending test email via %s:%d (SMTPS)...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Sending test email via %s:%d (SMTPS) (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Sending test email via %s:%d (SMTPS)...\n\n", config.Host, config.Port)
+		}
 	} else {
-		fmt.Printf("Sending test email via %s:%d...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Sending test email via %s:%d (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Sending test email via %s:%d...\n\n", config.Host, config.Port)
+		}
 	}
 
 	// Write CSV header
 	if shouldWrite, _ := csvLogger.ShouldWriteHeader(); shouldWrite {
 		if err := csvLogger.WriteHeader([]string{
-			"Action", "Status", "Server", "Port", "From", "To",
+			"Action", "Status", "Server", "Port", "Connect_Address", "From", "To",
 			"Subject", "SMTP_Response_Code", "Message_ID",
 			"TLS_Version", "Cipher_Suite", "Cipher_Strength",
 			"Cert_Subject", "Cert_Issuer", "Cert_SANs",
@@ -47,7 +55,7 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 		logger.LogError(slogLogger, "Connection failed", "error", err)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			config.From, strings.Join(config.To, ", "), config.Subject, "", "",
+			config.ConnectAddress, config.From, strings.Join(config.To, ", "), config.Subject, "", "",
 			"", "", "", "", "", "", "", "", "", // No TLS info on connection failure
 			err.Error(),
 		}); logErr != nil {
@@ -58,9 +66,17 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 	defer client.Close()
 
 	if config.SMTPS {
-		fmt.Printf("✓ Connected with SMTPS (implicit TLS)\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected with SMTPS (implicit TLS) via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected with SMTPS (implicit TLS)\n")
+		}
 	} else {
-		fmt.Printf("✓ Connected\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected\n")
+		}
 	}
 
 	// Send EHLO
@@ -70,7 +86,7 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 		logger.LogError(slogLogger, "EHLO failed", "error", err)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			config.From, strings.Join(config.To, ", "), config.Subject, "", "",
+			config.ConnectAddress, config.From, strings.Join(config.To, ", "), config.Subject, "", "",
 			"", "", "", "", "", "", "", "", "", // No TLS info on EHLO failure
 			err.Error(),
 		}); logErr != nil {
@@ -104,7 +120,7 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 			logger.LogError(slogLogger, "STARTTLS failed", "error", err)
 			if logErr := csvLogger.WriteRow([]string{
 				config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-				config.From, strings.Join(config.To, ", "), config.Subject, "", "",
+				config.ConnectAddress, config.From, strings.Join(config.To, ", "), config.Subject, "", "",
 				"", "", "", "", "", "", "", "", "", // No TLS info on STARTTLS failure
 				fmt.Sprintf("STARTTLS failed: %v", err),
 			}); logErr != nil {
@@ -138,7 +154,7 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 			tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 			if logErr := csvLogger.WriteRow([]string{
 				config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-				config.From, strings.Join(config.To, ", "), config.Subject, "", "",
+				config.ConnectAddress, config.From, strings.Join(config.To, ", "), config.Subject, "", "",
 				tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 				tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,
 				tlsData.CertValidFrom, tlsData.CertValidTo, tlsData.VerificationStatus,
@@ -166,7 +182,7 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 			tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 			if logErr := csvLogger.WriteRow([]string{
 				config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-				config.From, strings.Join(config.To, ", "), config.Subject, "", "",
+				config.ConnectAddress, config.From, strings.Join(config.To, ", "), config.Subject, "", "",
 				tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 				tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,
 				tlsData.CertValidFrom, tlsData.CertValidTo, tlsData.VerificationStatus,
@@ -194,7 +210,7 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 		tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			config.From, strings.Join(config.To, ", "), config.Subject, "", "",
+			config.ConnectAddress, config.From, strings.Join(config.To, ", "), config.Subject, "", "",
 			tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 			tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,
 			tlsData.CertValidFrom, tlsData.CertValidTo, tlsData.VerificationStatus,
@@ -212,7 +228,7 @@ func sendMail(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 	tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 	if logErr := csvLogger.WriteRow([]string{
 		config.Action, "SUCCESS", config.Host, fmt.Sprintf("%d", config.Port),
-		config.From, strings.Join(config.To, ", "), config.Subject,
+		config.ConnectAddress, config.From, strings.Join(config.To, ", "), config.Subject,
 		"250", messageID,
 		tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 		tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,

--- a/cmd/smtptool/smtp_client.go
+++ b/cmd/smtptool/smtp_client.go
@@ -82,7 +82,13 @@ func (c *SMTPClient) Connect(ctx context.Context) error {
 		return fmt.Errorf("rate limit wait failed: %w", err)
 	}
 
-	addr := fmt.Sprintf("%s:%d", c.host, c.port)
+	// Determine connection address (override or default to host)
+	connectHost := c.host
+	if c.config.ConnectAddress != "" {
+		connectHost = c.config.ConnectAddress
+		c.debugLogMessage(fmt.Sprintf("Using override connection address: %s (SNI will use: %s)", connectHost, c.host))
+	}
+	addr := net.JoinHostPort(connectHost, fmt.Sprintf("%d", c.port))
 
 	// Use context-aware dialer
 	dialer := &net.Dialer{

--- a/cmd/smtptool/testauth.go
+++ b/cmd/smtptool/testauth.go
@@ -15,15 +15,23 @@ import (
 // testAuth performs SMTP authentication testing.
 func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slogLogger *slog.Logger) error {
 	if config.SMTPS {
-		fmt.Printf("Testing SMTP authentication on %s:%d (SMTPS)...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Testing SMTP authentication on %s:%d (SMTPS) (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Testing SMTP authentication on %s:%d (SMTPS)...\n\n", config.Host, config.Port)
+		}
 	} else {
-		fmt.Printf("Testing SMTP authentication on %s:%d...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Testing SMTP authentication on %s:%d (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Testing SMTP authentication on %s:%d...\n\n", config.Host, config.Port)
+		}
 	}
 
 	// Write CSV header
 	if shouldWrite, _ := csvLogger.ShouldWriteHeader(); shouldWrite {
 		if err := csvLogger.WriteHeader([]string{
-			"Action", "Status", "Server", "Port", "Username",
+			"Action", "Status", "Server", "Port", "Connect_Address", "Username",
 			"Auth_Mechanisms_Available", "Auth_Method_Used", "Auth_Result",
 			"TLS_Version", "Cipher_Suite", "Cipher_Strength",
 			"Cert_Subject", "Cert_Issuer", "Cert_SANs",
@@ -42,7 +50,7 @@ func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 		logger.LogError(slogLogger, "Connection failed", "error", err)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			config.Username, "", "", "FAILURE",
+			config.ConnectAddress, config.Username, "", "", "FAILURE",
 			"", "", "", "", "", "", "", "", "", // No TLS info on connection failure
 			err.Error(),
 		}); logErr != nil {
@@ -53,9 +61,17 @@ func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 	defer client.Close()
 
 	if config.SMTPS {
-		fmt.Printf("✓ Connected with SMTPS (implicit TLS)\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected with SMTPS (implicit TLS) via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected with SMTPS (implicit TLS)\n")
+		}
 	} else {
-		fmt.Printf("✓ Connected\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected\n")
+		}
 	}
 
 	// Send EHLO
@@ -65,7 +81,7 @@ func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 		logger.LogError(slogLogger, "EHLO failed", "error", err)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			config.Username, "", "", "FAILURE",
+			config.ConnectAddress, config.Username, "", "", "FAILURE",
 			"", "", "", "", "", "", "", "", "", // No TLS info on EHLO failure
 			err.Error(),
 		}); logErr != nil {
@@ -82,7 +98,7 @@ func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 		logger.LogWarn(slogLogger, msg)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			config.Username, "none", "", "FAILURE",
+			config.ConnectAddress, config.Username, "none", "", "FAILURE",
 			"", "", "", "", "", "", "", "", "", // No TLS info yet
 			msg,
 		}); logErr != nil {
@@ -117,7 +133,7 @@ func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 			logger.LogError(slogLogger, "STARTTLS failed", "error", err)
 			if logErr := csvLogger.WriteRow([]string{
 				config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-				config.Username, strings.Join(authMechanisms, ", "), "", "FAILURE",
+				config.ConnectAddress, config.Username, strings.Join(authMechanisms, ", "), "", "FAILURE",
 				"", "", "", "", "", "", "", "", "", // No TLS info on STARTTLS failure
 				fmt.Sprintf("STARTTLS failed: %v", err),
 			}); logErr != nil {
@@ -157,7 +173,7 @@ func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 		tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			config.Username, strings.Join(authMechanisms, ", "), "", "FAILURE",
+			config.ConnectAddress, config.Username, strings.Join(authMechanisms, ", "), "", "FAILURE",
 			tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 			tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,
 			tlsData.CertValidFrom, tlsData.CertValidTo, tlsData.VerificationStatus,
@@ -204,7 +220,7 @@ func testAuth(ctx context.Context, config *Config, csvLogger logger.Logger, slog
 	tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 	if logErr := csvLogger.WriteRow([]string{
 		config.Action, status, config.Host, fmt.Sprintf("%d", config.Port),
-		config.Username, strings.Join(authMechanisms, ", "),
+		config.ConnectAddress, config.Username, strings.Join(authMechanisms, ", "),
 		methodUsed, authResult,
 		tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 		tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,

--- a/cmd/smtptool/testconnect.go
+++ b/cmd/smtptool/testconnect.go
@@ -13,15 +13,23 @@ import (
 // testConnect performs basic SMTP connectivity and capability testing.
 func testConnect(ctx context.Context, config *Config, csvLogger logger.Logger, slogLogger *slog.Logger) error {
 	if config.SMTPS {
-		fmt.Printf("Testing SMTPS connectivity to %s:%d...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Testing SMTPS connectivity to %s:%d (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Testing SMTPS connectivity to %s:%d...\n\n", config.Host, config.Port)
+		}
 	} else {
-		fmt.Printf("Testing SMTP connectivity to %s:%d...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Testing SMTP connectivity to %s:%d (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Testing SMTP connectivity to %s:%d...\n\n", config.Host, config.Port)
+		}
 	}
 
 	// Write CSV header
 	if shouldWrite, _ := csvLogger.ShouldWriteHeader(); shouldWrite {
 		if err := csvLogger.WriteHeader([]string{
-			"Action", "Status", "Server", "Port", "Connected", "Banner", "Capabilities", "Exchange_Detected",
+			"Action", "Status", "Server", "Port", "Connect_Address", "Connected", "Banner", "Capabilities", "Exchange_Detected",
 			"TLS_Version", "Cipher_Suite", "Cipher_Strength",
 			"Cert_Subject", "Cert_Issuer", "Cert_SANs",
 			"Cert_Valid_From", "Cert_Valid_To", "Cert_Verification_Status",
@@ -40,7 +48,7 @@ func testConnect(ctx context.Context, config *Config, csvLogger logger.Logger, s
 		logger.LogError(slogLogger, "Connection failed", "error", err)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host,
-			fmt.Sprintf("%d", config.Port), "false", "", "", "false",
+			fmt.Sprintf("%d", config.Port), config.ConnectAddress, "false", "", "", "false",
 			"", "", "", "", "", "", "", "", "", // No TLS info on connection failure
 			err.Error(),
 		}); logErr != nil {
@@ -51,9 +59,17 @@ func testConnect(ctx context.Context, config *Config, csvLogger logger.Logger, s
 	defer client.Close()
 
 	if config.SMTPS {
-		fmt.Printf("✓ Connected successfully with SMTPS (implicit TLS)\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected successfully with SMTPS (implicit TLS) via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected successfully with SMTPS (implicit TLS)\n")
+		}
 	} else {
-		fmt.Printf("✓ Connected successfully\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected successfully via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected successfully\n")
+		}
 	}
 	fmt.Printf("  Banner: %s\n\n", client.GetBanner())
 
@@ -73,7 +89,7 @@ func testConnect(ctx context.Context, config *Config, csvLogger logger.Logger, s
 		tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host,
-			fmt.Sprintf("%d", config.Port), "true", client.GetBanner(), "", "false",
+			fmt.Sprintf("%d", config.Port), config.ConnectAddress, "true", client.GetBanner(), "", "false",
 			tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 			tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,
 			tlsData.CertValidFrom, tlsData.CertValidTo, tlsData.VerificationStatus,
@@ -106,7 +122,7 @@ func testConnect(ctx context.Context, config *Config, csvLogger logger.Logger, s
 	tlsData := formatTLSInfoForCSV(tlsState, config.Host)
 	if logErr := csvLogger.WriteRow([]string{
 		config.Action, "SUCCESS", config.Host,
-		fmt.Sprintf("%d", config.Port), "true", client.GetBanner(),
+		fmt.Sprintf("%d", config.Port), config.ConnectAddress, "true", client.GetBanner(),
 		capsStr, fmt.Sprintf("%t", exchangeInfo.IsExchange),
 		tlsData.TLSVersion, tlsData.CipherSuite, tlsData.CipherStrength,
 		tlsData.CertSubject, tlsData.CertIssuer, tlsData.CertSANs,

--- a/cmd/smtptool/teststarttls.go
+++ b/cmd/smtptool/teststarttls.go
@@ -17,15 +17,23 @@ import (
 // For SMTPS mode, tests implicit TLS (TLS handshake happens immediately after TCP connect).
 func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, slogLogger *slog.Logger) error {
 	if config.SMTPS {
-		fmt.Printf("Testing SMTPS (implicit TLS) on %s:%d...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Testing SMTPS (implicit TLS) on %s:%d (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Testing SMTPS (implicit TLS) on %s:%d...\n\n", config.Host, config.Port)
+		}
 	} else {
-		fmt.Printf("Testing STARTTLS on %s:%d...\n\n", config.Host, config.Port)
+		if config.ConnectAddress != "" {
+			fmt.Printf("Testing STARTTLS on %s:%d (connecting via %s)...\n\n", config.Host, config.Port, config.ConnectAddress)
+		} else {
+			fmt.Printf("Testing STARTTLS on %s:%d...\n\n", config.Host, config.Port)
+		}
 	}
 
 	// Write CSV header
 	if shouldWrite, _ := csvLogger.ShouldWriteHeader(); shouldWrite {
 		if err := csvLogger.WriteHeader([]string{
-			"Action", "Status", "Server", "Port", "STARTTLS_Available",
+			"Action", "Status", "Server", "Port", "Connect_Address", "STARTTLS_Available",
 			"TLS_Version", "Cipher_Suite", "Cert_Subject", "Cert_Issuer",
 			"Cert_Valid_From", "Cert_Valid_To", "Cert_SANs",
 			"Verification_Status", "Warnings", "Error",
@@ -42,7 +50,7 @@ func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, 
 		logger.LogError(slogLogger, "Connection failed", "error", err)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			"unknown", "", "", "", "", "", "", "", "", "", err.Error(),
+			config.ConnectAddress, "unknown", "", "", "", "", "", "", "", "", "", err.Error(),
 		}); logErr != nil {
 			logger.LogError(slogLogger, "Failed to write CSV row", "error", logErr)
 		}
@@ -51,9 +59,17 @@ func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, 
 	defer client.Close()
 
 	if config.SMTPS {
-		fmt.Printf("✓ Connected with SMTPS (implicit TLS)\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected with SMTPS (implicit TLS) via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected with SMTPS (implicit TLS)\n")
+		}
 	} else {
-		fmt.Printf("✓ Connected\n")
+		if config.ConnectAddress != "" {
+			fmt.Printf("✓ Connected via %s\n", config.ConnectAddress)
+		} else {
+			fmt.Printf("✓ Connected\n")
+		}
 	}
 
 	// Send EHLO
@@ -63,7 +79,7 @@ func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, 
 		logger.LogError(slogLogger, "EHLO failed", "error", err)
 		if logErr := csvLogger.WriteRow([]string{
 			config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-			"unknown", "", "", "", "", "", "", "", "", "", err.Error(),
+			config.ConnectAddress, "unknown", "", "", "", "", "", "", "", "", "", err.Error(),
 		}); logErr != nil {
 			logger.LogError(slogLogger, "Failed to write CSV row", "error", logErr)
 		}
@@ -80,7 +96,7 @@ func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, 
 			logger.LogError(slogLogger, msg)
 			if logErr := csvLogger.WriteRow([]string{
 				config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-				"N/A (SMTPS)", "", "", "", "", "", "", "", "", "", msg,
+				config.ConnectAddress, "N/A (SMTPS)", "", "", "", "", "", "", "", "", "", msg,
 			}); logErr != nil {
 				logger.LogError(slogLogger, "Failed to write CSV row", "error", logErr)
 			}
@@ -95,7 +111,7 @@ func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, 
 			logger.LogWarn(slogLogger, msg)
 			if logErr := csvLogger.WriteRow([]string{
 				config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-				"false", "", "", "", "", "", "", "", "", "", msg,
+				config.ConnectAddress, "false", "", "", "", "", "", "", "", "", "", msg,
 			}); logErr != nil {
 				logger.LogError(slogLogger, "Failed to write CSV row", "error", logErr)
 			}
@@ -124,7 +140,7 @@ func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, 
 			logger.LogError(slogLogger, "STARTTLS handshake failed", "error", err)
 			if logErr := csvLogger.WriteRow([]string{
 				config.Action, "FAILURE", config.Host, fmt.Sprintf("%d", config.Port),
-				"true", "", "", "", "", "", "", "", "", "", err.Error(),
+				config.ConnectAddress, "true", "", "", "", "", "", "", "", "", "", err.Error(),
 			}); logErr != nil {
 				logger.LogError(slogLogger, "Failed to write CSV row", "error", logErr)
 			}
@@ -183,6 +199,7 @@ func testStartTLS(ctx context.Context, config *Config, csvLogger logger.Logger, 
 	// Log to CSV
 	if logErr := csvLogger.WriteRow([]string{
 		config.Action, "SUCCESS", config.Host, fmt.Sprintf("%d", config.Port),
+		config.ConnectAddress,
 		starttlsAvailable,
 		tlsInfo.Version,
 		tlsInfo.CipherSuite,

--- a/internal/common/version/version.go
+++ b/internal/common/version/version.go
@@ -8,7 +8,7 @@ package version
 // 1. Change the Version constant below
 // 2. Create a changelog entry in ChangeLog/{version}.md
 // 3. Commit with message: "Bump version to {version}"
-const Version = "2.6.18"
+const Version = "2.6.19"
 
 // Get returns the current version string.
 // This is a convenience function for accessing the Version constant.

--- a/internal/common/version/version.go
+++ b/internal/common/version/version.go
@@ -8,7 +8,7 @@ package version
 // 1. Change the Version constant below
 // 2. Create a changelog entry in ChangeLog/{version}.md
 // 3. Commit with message: "Bump version to {version}"
-const Version = "2.6.19"
+const Version = "2.7.0"
 
 // Get returns the current version string.
 // This is a convenience function for accessing the Version constant.


### PR DESCRIPTION
## Summary

- Add `-address` flag to imaptool, pop3tool, and jmaptool (matching smtptool)
- Allows connecting to specific IP/hostname while using original `-host` for TLS SNI and certificate verification
- Useful for testing servers behind load balancers or DNS round-robin
- Update documentation for all tools

## Test plan

- [x] Build all tools successfully (`go build ./cmd/...`)
- [x] Verify `go vet` passes
- [x] Verify help text shows new `-address` flag
- [x] Test connection override with real servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)