### PR TITLE
Update repository URLs from msgraphtool to gomailtesttool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Microsoft Graph & SMTP Testing Tools
 
-**Repository:** [https://github.com/ziembor/msgraphtool](https://github.com/ziembor/msgraphtool)
+**Repository:** [https://github.com/ziembor/gomailtesttool](https://github.com/ziembor/gomailtesttool)
 
 ## Overview
 

--- a/ChangeLog/1.15.1.md
+++ b/ChangeLog/1.15.1.md
@@ -45,7 +45,7 @@
   - Added version information to help header
   - Included environment variables documentation section
   - Added usage examples in help output
-  - Repository link: https://github.com/ziembor/msgraphtool
+  - Repository link: https://github.com/ziembor/gomailtesttool
   - Help automatically displays on validation errors
 
 - **Documentation updates**

--- a/ChangeLog/1.16.10.md
+++ b/ChangeLog/1.16.10.md
@@ -352,4 +352,4 @@ This is a drop-in replacement for v1.16.9. No configuration changes required.
 
 ---
 
-**Full Changelog:** https://github.com/ziembor/msgraphtool/compare/v1.16.9...v1.16.10
+**Full Changelog:** https://github.com/ziembor/gomailtesttool/compare/v1.16.9...v1.16.10

--- a/ChangeLog/1.16.9.md
+++ b/ChangeLog/1.16.9.md
@@ -180,4 +180,4 @@ This is a drop-in replacement for v1.16.8. No configuration changes required.
 
 ---
 
-**Full Changelog:** https://github.com/ziembor/msgraphtool/compare/v1.16.8...v1.16.9
+**Full Changelog:** https://github.com/ziembor/gomailtesttool/compare/v1.16.8...v1.16.9

--- a/ChangeLog/2.1.1.md
+++ b/ChangeLog/2.1.1.md
@@ -250,7 +250,7 @@ No configuration changes or command-line flag changes required.
 
 ## Links
 
-- **Repository**: https://github.com/ziembor/msgraphtool
+- **Repository**: https://github.com/ziembor/gomailtesttool
 - **Release Tag**: v2.1.1
 - **Previous Release**: v2.1.0 (2026-01-09)
 - **Security Policy**: SECURITY.md

--- a/ChangeLog/2.2.0.md
+++ b/ChangeLog/2.2.0.md
@@ -445,7 +445,7 @@ if err := limiter.Wait(ctx); err != nil {
 
 ## Links
 
-- **Repository**: https://github.com/ziembor/msgraphtool
+- **Repository**: https://github.com/ziembor/gomailtesttool
 - **Release Tag**: v2.2.0
 - **Previous Release**: v2.1.1 (2026-01-09)
 - **Security Policy**: SECURITY.md

--- a/ChangeLog/2.3.0.md
+++ b/ChangeLog/2.3.0.md
@@ -306,7 +306,7 @@ The debug logging feature maintains security best practices:
 
 ## Links
 
-- **Repository**: https://github.com/ziembor/msgraphtool
+- **Repository**: https://github.com/ziembor/gomailtesttool
 - **Release Tag**: v2.3.0
 - **Previous Release**: v2.2.0 (2026-01-09)
 - **SMTP Tool Documentation**: SMTP_TOOL_README.md

--- a/ChangeLog/2.3.2.md
+++ b/ChangeLog/2.3.2.md
@@ -363,7 +363,7 @@ This change maintains the existing security posture:
 
 ## Links
 
-- **Repository**: https://github.com/ziembor/msgraphtool
+- **Repository**: https://github.com/ziembor/gomailtesttool
 - **Release Tag**: v2.3.2
 - **Previous Release**: v2.3.1 (2026-01-17)
 - **Related Issue**: #34 - Bug: smtptool sendmail action fails with STARTTLS on certain configurations

--- a/ChangeLog/2.3.3.md
+++ b/ChangeLog/2.3.3.md
@@ -427,7 +427,7 @@ smtptool.exe -action teststarttls -host smtp.example.com -port 587 -tlsversion 1
 
 ## Links
 
-- **Repository**: https://github.com/ziembor/msgraphtool
+- **Repository**: https://github.com/ziembor/gomailtesttool
 - **Release Tag**: v2.3.3
 - **Previous Release**: v2.3.2 (2026-01-17)
 - **SMTP Tool Documentation**: SMTP_TOOL_README.md

--- a/IMAPTOOL_README.md
+++ b/IMAPTOOL_README.md
@@ -384,6 +384,6 @@ All operations are automatically logged to action-specific CSV files:
 
 ## Support
 
-**Repository:** [https://github.com/ziembor/msgraphtool](https://github.com/ziembor/msgraphtool)
+**Repository:** [https://github.com/ziembor/gomailtesttool](https://github.com/ziembor/gomailtesttool)
 
                           ..ooOO END OOoo..

--- a/INTEGRATION_TESTS.md
+++ b/INTEGRATION_TESTS.md
@@ -384,7 +384,7 @@ For issues or questions:
 - See main [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common errors
 - Check [SECURITY_PRACTICES.md](SECURITY_PRACTICES.md) for security guidance
 - Review [README.md](README.md) for general usage information
-- Report issues at: https://github.com/ziembor/msgraphtool/issues
+- Report issues at: https://github.com/ziembor/gomailtesttool/issues
 
 ---
 

--- a/JMAPTOOL_README.md
+++ b/JMAPTOOL_README.md
@@ -403,6 +403,6 @@ All operations are automatically logged to action-specific CSV files:
 
 ## Support
 
-**Repository:** [https://github.com/ziembor/msgraphtool](https://github.com/ziembor/msgraphtool)
+**Repository:** [https://github.com/ziembor/gomailtesttool](https://github.com/ziembor/gomailtesttool)
 
                           ..ooOO END OOoo..

--- a/MSGRAPHTOOL_README.md
+++ b/MSGRAPHTOOL_README.md
@@ -417,6 +417,6 @@ Configure automatic retry for transient failures:
 
 ## Support
 
-**Repository:** [https://github.com/ziembor/msgraphtool](https://github.com/ziembor/msgraphtool)
+**Repository:** [https://github.com/ziembor/gomailtesttool](https://github.com/ziembor/gomailtesttool)
 
                           ..ooOO END OOoo..

--- a/POP3TOOL_README.md
+++ b/POP3TOOL_README.md
@@ -383,6 +383,6 @@ All operations are automatically logged to action-specific CSV files:
 
 ## Support
 
-**Repository:** [https://github.com/ziembor/msgraphtool](https://github.com/ziembor/msgraphtool)
+**Repository:** [https://github.com/ziembor/gomailtesttool](https://github.com/ziembor/gomailtesttool)
 
                           ..ooOO END OOoo..

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Portable, single-binary CLI tools for testing and managing email infrastructure - both cloud (Exchange Online via Microsoft Graph) and on-premises (SMTP servers).
 
-**Repository:** [https://github.com/ziembor/msgraphtool](https://github.com/ziembor/msgraphtool)
+**Repository:** [https://github.com/ziembor/gomailtesttool](https://github.com/ziembor/gomailtesttool)
 
 ## Purpose
 

--- a/SMTP_TOOL_README.md
+++ b/SMTP_TOOL_README.md
@@ -879,6 +879,6 @@ Write-Host "View emails at: http://localhost:8025" -ForegroundColor Cyan
 ## Support
 
 **Issues and Feedback:**
-- GitHub: [https://github.com/ziembor/msgraphtool/issues](https://github.com/ziembor/msgraphtool/issues)
+- GitHub: [https://github.com/ziembor/gomailtesttool/issues](https://github.com/ziembor/gomailtesttool/issues)
 
                           ..ooOO END OOoo..

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -607,7 +607,7 @@ If you continue to experience issues:
    ```
 
 4. **Report issues:**
-   - GitHub: https://github.com/ziembor/msgraphtool/issues
+   - GitHub: https://github.com/ziembor/gomailtesttool/issues
    - Include: Version, command used, error message, verbose output (with secrets redacted)
 
 ---


### PR DESCRIPTION
## Summary

- Update all repository URL references from `github.com/ziembor/msgraphtool` to `github.com/ziembor/gomailtesttool`
- 17 files updated across README files, tool documentation, and changelogs

## Test plan

- [x] Verified no remaining occurrences of old URL
- [x] All markdown files compile correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)