### PR TITLE
Consolidate multiple tools into unified gomailtest binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,55 +88,46 @@ jobs:
     - name: Create bin directory
       run: mkdir -p bin
 
-    - name: Build all tools
+    - name: Build binary
       env:
         GOARCH: ${{ matrix.goarch }}
       run: |
-        go build -ldflags="-s -w" -o bin/msgraphtool${{ matrix.ext }} ./cmd/msgraphtool
-        go build -ldflags="-s -w" -o bin/smtptool${{ matrix.ext }} ./cmd/smtptool
-        go build -ldflags="-s -w" -o bin/imaptool${{ matrix.ext }} ./cmd/imaptool
-        go build -ldflags="-s -w" -o bin/pop3tool${{ matrix.ext }} ./cmd/pop3tool
-        go build -ldflags="-s -w" -o bin/jmaptool${{ matrix.ext }} ./cmd/jmaptool
+        go build -ldflags="-s -w" -o bin/gomailtest${{ matrix.ext }} ./cmd/gomailtest
 
     - name: Verify build output (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        $tools = @("msgraphtool", "smtptool", "imaptool", "pop3tool", "jmaptool")
-        foreach ($tool in $tools) {
-          $binary = "bin\$tool${{ matrix.ext }}"
-          if (Test-Path $binary) {
-            Write-Host "✓ $tool build successful"
-            Get-Item $binary | Select-Object Name, Length
-          } else {
-            Write-Error "✗ $tool build failed"
-            exit 1
-          }
+        $binary = "bin\gomailtest${{ matrix.ext }}"
+        if (Test-Path $binary) {
+          Write-Host "✓ gomailtest build successful"
+          Get-Item $binary | Select-Object Name, Length
+        } else {
+          Write-Error "✗ gomailtest build failed"
+          exit 1
         }
 
     - name: Verify build output (Linux/macOS)
       if: matrix.os != 'windows-latest'
       run: |
-        for tool in msgraphtool smtptool imaptool pop3tool jmaptool; do
-          if [ -f "bin/$tool${{ matrix.ext }}" ]; then
-            echo "✓ $tool build successful"
-            ls -lh "bin/$tool${{ matrix.ext }}"
-          else
-            echo "✗ $tool build failed"
-            exit 1
-          fi
-        done
+        if [ -f "bin/gomailtest${{ matrix.ext }}" ]; then
+          echo "✓ gomailtest build successful"
+          ls -lh "bin/gomailtest${{ matrix.ext }}"
+        else
+          echo "✗ gomailtest build failed"
+          exit 1
+        fi
 
     - name: Create ZIP archive (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        Compress-Archive -Path bin\msgraphtool${{ matrix.ext }},bin\smtptool${{ matrix.ext }},bin\imaptool${{ matrix.ext }},bin\pop3tool${{ matrix.ext }},bin\jmaptool${{ matrix.ext }},README.md,IMAPTOOL_README.md,JMAPTOOL_README.md,MSGRAPHTOOL_README.md,POP3TOOL_README.md,SMTP_TOOL_README.md,EXAMPLES.md,LICENSE -DestinationPath ${{ matrix.zip_name }}
+        Compress-Archive -Path bin\gomailtest${{ matrix.ext }},README.md,IMAPTOOL_README.md,JMAPTOOL_README.md,MSGRAPHTOOL_README.md,POP3TOOL_README.md,SMTP_TOOL_README.md,EXAMPLES.md,LICENSE -DestinationPath ${{ matrix.zip_name }}
         Write-Host "Created ZIP archive: ${{ matrix.zip_name }}"
         Get-Item ${{ matrix.zip_name }} | Select-Object Name, Length
 
     - name: Create ZIP archive (Linux/macOS)
       if: matrix.os != 'windows-latest'
       run: |
-        cd bin && zip ../${{ matrix.zip_name }} msgraphtool${{ matrix.ext }} smtptool${{ matrix.ext }} imaptool${{ matrix.ext }} pop3tool${{ matrix.ext }} jmaptool${{ matrix.ext }} && cd ..
+        cd bin && zip ../${{ matrix.zip_name }} gomailtest${{ matrix.ext }} && cd ..
         zip -u ${{ matrix.zip_name }} README.md IMAPTOOL_README.md JMAPTOOL_README.md MSGRAPHTOOL_README.md POP3TOOL_README.md SMTP_TOOL_README.md EXAMPLES.md LICENSE
         echo "Created ZIP archive: ${{ matrix.zip_name }}"
         ls -lh ${{ matrix.zip_name }}
@@ -158,12 +149,8 @@ jobs:
 
           ### What's Included
 
-          Each ZIP archive contains 5 tools:
-          - **msgraphtool** - Microsoft Graph API tool for Exchange Online
-          - **smtptool** - SMTP connectivity and TLS testing
-          - **imaptool** - IMAP server testing with XOAUTH2 support
-          - **pop3tool** - POP3 server testing with XOAUTH2 support
-          - **jmaptool** - JMAP protocol testing
+          Each ZIP archive contains a single unified binary:
+          - **gomailtest** - Unified CLI for all protocols (smtp, imap, pop3, jmap, msgraph subcommands)
 
           Plus documentation:
           - **README.md** - Main documentation
@@ -176,68 +163,68 @@ jobs:
           **Windows (amd64):**
           1. Download `gomailtesttool-windows-amd64.zip`
           2. Extract the ZIP file
-          3. Run any tool directly (e.g., `smtptool.exe -help`)
+          3. Run: `gomailtest.exe --help`
 
           **Linux (amd64):**
           1. Download `gomailtesttool-linux-amd64.zip`
           2. Extract: `unzip gomailtesttool-linux-amd64.zip`
-          3. Make executable: `chmod +x *tool`
-          4. Run: `./smtptool -help`
+          3. Make executable: `chmod +x gomailtest`
+          4. Run: `./gomailtest --help`
 
           **macOS (Apple Silicon/arm64):**
           1. Download `gomailtesttool-macos-arm64.zip`
           2. Extract: `unzip gomailtesttool-macos-arm64.zip`
-          3. Make executable: `chmod +x *tool`
-          4. Run: `./smtptool -help`
+          3. Make executable: `chmod +x gomailtest`
+          4. Run: `./gomailtest --help`
 
           **Note for macOS:** If you see "cannot be opened because the developer cannot be verified":
           - Right-click the binary and select "Open", or
-          - Run: `xattr -d com.apple.quarantine *tool`
+          - Run: `xattr -d com.apple.quarantine gomailtest`
 
           ### Quick Start Examples
 
           **SMTP Testing:**
           ```bash
           # Test connectivity
-          ./smtptool -action testconnect -host smtp.example.com -port 25
+          ./gomailtest smtp testconnect -host smtp.example.com -port 25
 
           # TLS diagnostics
-          ./smtptool -action teststarttls -host smtp.example.com -port 587
+          ./gomailtest smtp teststarttls -host smtp.example.com -port 587
           ```
 
           **IMAP Testing:**
           ```bash
           # Test connection
-          ./imaptool -action testconnect -host imap.gmail.com -imaps
+          ./gomailtest imap testconnect -host imap.gmail.com -imaps
 
           # List folders with OAuth2
-          ./imaptool -action listfolders -host imap.gmail.com -imaps \
+          ./gomailtest imap listfolders -host imap.gmail.com -imaps \
             -username user@gmail.com -accesstoken "ya29..."
           ```
 
           **POP3 Testing:**
           ```bash
           # Test connection
-          ./pop3tool -action testconnect -host pop.gmail.com -pop3s
+          ./gomailtest pop3 testconnect -host pop.gmail.com -pop3s
 
           # List mail
-          ./pop3tool -action listmail -host pop.gmail.com -pop3s \
+          ./gomailtest pop3 listmail -host pop.gmail.com -pop3s \
             -username user@gmail.com -password "app-password"
           ```
 
           **JMAP Testing:**
           ```bash
           # Discover session
-          ./jmaptool -action testconnect -host jmap.fastmail.com
+          ./gomailtest jmap testconnect -host jmap.fastmail.com
 
           # Get mailboxes
-          ./jmaptool -action getmailboxes -host jmap.fastmail.com \
+          ./gomailtest jmap getmailboxes -host jmap.fastmail.com \
             -username user@fastmail.com -accesstoken "token"
           ```
 
           **Microsoft Graph:**
           ```bash
-          ./msgraphtool -tenantid "..." -clientid "..." -secret "..." \
+          ./gomailtest msgraph -tenantid "..." -clientid "..." -secret "..." \
             -mailbox "user@example.com" -action getinbox
           ```
 


### PR DESCRIPTION
## Summary
This PR consolidates five separate CLI tools (msgraphtool, smtptool, imaptool, pop3tool, jmaptool) into a single unified binary called `gomailtest` with protocol-specific subcommands.

## Key Changes
- **Build process**: Updated CI/CD workflow to build a single `gomailtest` binary instead of five separate tools
- **Binary structure**: Changed from individual executables to a unified CLI with subcommands (e.g., `gomailtest smtp`, `gomailtest imap`, `gomailtest pop3`, `gomailtest jmap`, `gomailtest msgraph`)
- **Verification steps**: Simplified build verification to check only the single `gomailtest` binary on all platforms (Windows, Linux, macOS)
- **Archive creation**: Updated ZIP archive generation to include only the unified binary instead of five separate executables
- **Documentation**: Updated release notes and quick start examples to reflect the new unified command structure and subcommand syntax
- **Usage examples**: Changed all example commands from tool-specific flags (e.g., `smtptool -action testconnect`) to unified subcommand format (e.g., `gomailtest smtp testconnect`)

## Implementation Details
- The workflow now builds a single binary from `./cmd/gomailtest` instead of building from five separate command directories
- All platform-specific build verification and archiving logic has been simplified to handle one binary
- Release documentation has been updated to guide users on the new unified interface while maintaining references to the original tool-specific README files for protocol details

https://claude.ai/code/session_01CBZDcCNEFkqBuXjoFqE9Jp