### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/internal/protocols/pop3/pop3_client.go
+++ b/internal/protocols/pop3/pop3_client.go
@@ -3,7 +3,6 @@ package pop3
 import (
 	"bufio"
 	"context"
-	"crypto/md5"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
@@ -258,29 +257,7 @@ func (c *POP3Client) authUSER(username, password string) error {
 
 // authAPOP performs APOP authentication.
 func (c *POP3Client) authAPOP(username, password string) error {
-	// Extract timestamp from greeting
-	timestamp := protocol.ParseGreeting(c.greeting)
-	if timestamp == "" {
-		return fmt.Errorf("APOP not supported: no timestamp in greeting")
-	}
-
-	// Calculate MD5 digest
-	digest := fmt.Sprintf("%x", md5.Sum([]byte(timestamp+password)))
-
-	// Send APOP command
-	if _, err := c.conn.Write([]byte(protocol.APOP(username, digest))); err != nil {
-		return fmt.Errorf("failed to send APOP: %w", err)
-	}
-
-	resp, err := protocol.ReadResponse(c.reader)
-	if err != nil {
-		return fmt.Errorf("failed to read APOP response: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("APOP failed: %s", resp.Message)
-	}
-
-	return nil
+	return fmt.Errorf("APOP authentication is disabled: protocol requires insecure MD5 challenge-response; use USER/PASS over TLS")
 }
 
 // authXOAUTH2 performs XOAUTH2 authentication.


### PR DESCRIPTION
Potential fix for [https://github.com/ziembor/gomailtesttool/security/code-scanning/1](https://github.com/ziembor/gomailtesttool/security/code-scanning/1)

General fix: avoid using weak hash algorithms (MD5/SHA1) with sensitive data. For POP3 auth, remove or block legacy APOP-MD5 authentication and use a stronger alternative path already present in the client (`authUSER`) with TLS protection.

Best fix in this file: in `internal/protocols/pop3/pop3_client.go`, remove the MD5 import and change `authAPOP` to return an explicit error indicating APOP is disabled due to insecure MD5 requirements. This preserves compilation and avoids introducing incompatible pseudo-APOP behavior. It also keeps existing functionality intact for secure auth paths (USER/PASS over TLS), while preventing weak-hash usage.

Changes needed:
- Imports: remove `crypto/md5`.
- Method body: replace `authAPOP` implementation with a hard fail message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
