### PR TITLE
feat: HTTP/REST serve subcommand (v3.3.3)

### DIFF
--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -39,6 +39,7 @@ func New(cfg *Config, smtpBase *smtp.Config, msgraphBase *msgraph.Config, graphC
 // Run starts the HTTP server and blocks until ctx is cancelled or the server errors.
 func (s *Server) Run(ctx context.Context) error {
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", s.handleSummary)
 	mux.HandleFunc("GET /health", s.handleHealth)
 	mux.HandleFunc("POST /smtp/sendmail", s.handleSMTPSendMail)
 	mux.HandleFunc("POST /msgraph/sendmail", s.handleMsgraphSendMail)
@@ -72,10 +73,11 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 }
 
-// apiKeyMiddleware enforces X-API-Key on all routes except /health.
+// apiKeyMiddleware enforces X-API-Key on all routes except /health and GET /.
 func (s *Server) apiKeyMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/health" && subtle.ConstantTimeCompare([]byte(r.Header.Get("X-API-Key")), []byte(s.config.APIKey)) != 1 {
+		exempt := r.URL.Path == "/health" || (r.URL.Path == "/" && r.Method == http.MethodGet)
+		if !exempt && subtle.ConstantTimeCompare([]byte(r.Header.Get("X-API-Key")), []byte(s.config.APIKey)) != 1 {
 			writeJSON(w, http.StatusUnauthorized, apiResponse{Status: "error", Message: "missing or invalid X-API-Key"})
 			return
 		}
@@ -85,6 +87,30 @@ func (s *Server) apiKeyMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "version": version.Get()})
+}
+
+func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
+	type endpointInfo struct {
+		Method      string `json:"method"`
+		Path        string `json:"path"`
+		Description string `json:"description"`
+		Available   bool   `json:"available"`
+	}
+	type summaryResponse struct {
+		Name      string         `json:"name"`
+		Version   string         `json:"version"`
+		Endpoints []endpointInfo `json:"endpoints"`
+	}
+	writeJSON(w, http.StatusOK, summaryResponse{
+		Name:    "gomailtest serve",
+		Version: version.Get(),
+		Endpoints: []endpointInfo{
+			{Method: "GET", Path: "/health", Description: "Health check (no API key required)", Available: true},
+			{Method: "POST", Path: "/smtp/sendmail", Description: "Send email via SMTP (X-API-Key required)", Available: s.smtpBase != nil},
+			{Method: "POST", Path: "/msgraph/sendmail", Description: "Send email via Microsoft Graph (X-API-Key required)", Available: s.msgraphBase != nil && s.graphClient != nil},
+			{Method: "POST", Path: "/ews/sendmail", Description: "Send email via EWS — not yet implemented", Available: false},
+		},
+	})
 }
 
 // apiResponse is the standard JSON envelope for all endpoint responses.


### PR DESCRIPTION
## Summary

- Add `serve` subcommand: HTTP REST server exposing email-sending endpoints for SMTP, Microsoft Graph, and EWS (stub)
- Credentials loaded from environment variables at startup; no credentials in request bodies
- `GET /` returns a JSON summary of available endpoints and their availability status
- All non-health/non-summary endpoints require `X-API-Key` header

## Endpoints

| Method | Path | Auth |
|--------|------|------|
| `GET` | `/` | none |
| `GET` | `/health` | none |
| `POST` | `/smtp/sendmail` | X-API-Key |
| `POST` | `/msgraph/sendmail` | X-API-Key |
| `POST` | `/ews/sendmail` | X-API-Key (501) |

## Test plan

- [ ] `gomailtest serve --api-key test` starts and `GET /` returns JSON summary with correct `available` flags
- [ ] `GET /health` returns `{"status":"ok","version":"..."}`
- [ ] `POST /smtp/sendmail` without key returns 401; with key and valid SMTP env returns 200
- [ ] `POST /msgraph/sendmail` without key returns 401; with Graph env returns 200
- [ ] Unit tests pass: `go test ./internal/serve/...`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)