### PR TITLE
Potential fix for code scanning alert no. 2: Email content injection

### DIFF
--- a/internal/protocols/smtp/sendmail.go
+++ b/internal/protocols/smtp/sendmail.go
@@ -269,7 +269,7 @@ func writeSMTPCSVRow(csvLogger logger.Logger, row []string) error {
 // buildEmailMessage constructs an RFC 5322 email message.
 // Defense-in-Depth: Email headers (From, To, Subject) are sanitized to remove
 // CRLF sequences that could be used for header injection attacks. The message
-// body is not sanitized as it legitimately may contain newlines.
+// body is sanitized to normalize newlines and strip unsafe control characters.
 func buildEmailMessage(from string, to []string, subject, body string) []byte {
 	messageID := generateMessageID("")
 	date := time.Now().Format(time.RFC1123Z)
@@ -281,6 +281,7 @@ func buildEmailMessage(from string, to []string, subject, body string) []byte {
 	for i, addr := range to {
 		sanitizedTo[i] = sanitizeEmailHeader(addr)
 	}
+	body = sanitizeEmailBody(body)
 
 	message := fmt.Sprintf("Message-ID: <%s>\r\n", messageID)
 	message += fmt.Sprintf("Date: %s\r\n", date)
@@ -302,6 +303,22 @@ func sanitizeEmailHeader(header string) string {
 	header = strings.ReplaceAll(header, "\r", "")
 	header = strings.ReplaceAll(header, "\n", "")
 	return header
+}
+
+// sanitizeEmailBody normalizes line endings and removes unsafe control
+// characters from body content while preserving regular text formatting.
+func sanitizeEmailBody(body string) string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\r", "\n")
+
+	var b strings.Builder
+	b.Grow(len(body))
+	for _, r := range body {
+		if r == '\n' || r == '\t' || r >= 0x20 {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // generateMessageID creates a unique message ID.


### PR DESCRIPTION
Potential fix for [https://github.com/ziembor/gomailtesttool/security/code-scanning/2](https://github.com/ziembor/gomailtesttool/security/code-scanning/2)

General fix: sanitize untrusted email body content before it is inserted into the RFC 5322 message, using a conservative normalization that removes dangerous control characters while preserving expected text/newlines.

Best minimal fix without changing architecture: in `internal/protocols/smtp/sendmail.go`, sanitize `body` inside `buildEmailMessage` before concatenating it into the message. Keep current header sanitization intact. Add a helper that:
- normalizes `\r\n` and lone `\r` to `\n`,
- removes NUL and other non-printable control chars except `\n` and `\t`,
- returns cleaned text used in message assembly.

This addresses both alert variants because both taint paths converge to the same sink (`w.Write(data)`) through `buildEmailMessage`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
