### PR TITLE
Potential fix for code scanning alert no. 2: Email content injection

### DIFF
--- a/internal/serve/smtp_handler.go
+++ b/internal/serve/smtp_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"msgraphtool/internal/common/logger"
@@ -17,6 +18,26 @@ type smtpSendRequest struct {
 	From    string   `json:"from,omitempty"` // optional override for SMTPFROM
 	Subject string   `json:"subject"`
 	Body    string   `json:"body,omitempty"`
+}
+
+func sanitizeEmailSubjectInput(subject string) string {
+	subject = strings.ReplaceAll(subject, "\r", "")
+	subject = strings.ReplaceAll(subject, "\n", "")
+	return strings.TrimSpace(subject)
+}
+
+func sanitizeEmailBodyInput(body string) string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\r", "\n")
+
+	var b strings.Builder
+	b.Grow(len(body))
+	for _, r := range body {
+		if r == '\n' || r == '\t' || r >= 0x20 {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func (s *Server) handleSMTPSendMail(w http.ResponseWriter, r *http.Request) {
@@ -61,8 +82,8 @@ func (s *Server) handleSMTPSendMail(w http.ResponseWriter, r *http.Request) {
 	// Clone base config and overlay request content
 	cfg := *s.smtpBase
 	cfg.To = req.To
-	cfg.Subject = req.Subject
-	cfg.Body = req.Body
+	cfg.Subject = sanitizeEmailSubjectInput(req.Subject)
+	cfg.Body = sanitizeEmailBodyInput(req.Body)
 	cfg.Action = smtp.ActionSendMail
 	if req.From != "" {
 		cfg.From = req.From


### PR DESCRIPTION
Potential fix for [https://github.com/ziembor/gomailtesttool/security/code-scanning/2](https://github.com/ziembor/gomailtesttool/security/code-scanning/2)

General fix: sanitize/normalize untrusted email fields at request handling time before placing them into config, so downstream SMTP writing only receives pre-sanitized content. This is the best single fix because it addresses both alert variants at the trust boundary (`r.Body` flow), preserves existing behavior, and complements existing sanitization in `buildEmailMessage`.

Best concrete change:
- In `internal/serve/smtp_handler.go`, add local sanitization helpers for subject/body.
- Apply them when assigning `cfg.Subject` and `cfg.Body` (lines around current 64–65 in provided snippet).
- Use existing `strings` package functions (add `strings` import) to:
  - strip CR/LF from subject to avoid header-shaping behavior and normalize whitespace;
  - normalize body newlines and remove unsafe control chars except `\n` and `\t`.

No external dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
