### PR TITLE
Add SASL OAUTHBEARER (RFC 7628) authentication for SMTP

### DIFF
--- a/ChangeLog/3.3.8.md
+++ b/ChangeLog/3.3.8.md
@@ -1,0 +1,4 @@
+# 3.3.8 — 2026-05-31
+
+## Added
+- SASL **OAUTHBEARER** (RFC 7628) authentication for SMTP (`testauth`, `sendmail`), selectable via `--authmethod OAUTHBEARER` and supplied with the existing `--accesstoken` / `SMTPACCESSTOKEN`. Carries OAuth 2.0 or OAuth 2.1 bearer tokens (the SASL layer is identical for both). Auto-select prefers `XOAUTH2` first, then `OAUTHBEARER`, when a token is present. See `migration/3.3.8_OAUTHBEARER_SMTP.md`.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ gomailtest smtp testauth --host exchange.contoso.com --port 25 \
 gomailtest smtp testauth --host smtp.office365.com --port 587 \
   --username user@company.com --accesstoken "eyJ..."
 
+# OAUTHBEARER — RFC 7628 SASL OAuth (OAuth 2.0/2.1 tokens)
+gomailtest smtp testauth --host smtp.example.com --port 587 \
+  --username user@example.com --accesstoken "eyJ..." --authmethod OAUTHBEARER
+
 # Send test email
 gomailtest smtp sendmail --host smtp.example.com --port 587 \
   --username user@example.com --password "..." \

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -36,6 +36,7 @@ This document provides a comprehensive comparison of all tools in the gomailtest
 | LOGIN | ✅ | ✅ | - | - | - | - |
 | CRAM-MD5 | ✅ | - | - | - | - | - |
 | XOAUTH2 | ✅ | ✅ | ✅ | - | - | - |
+| OAUTHBEARER | ✅ | - | - | - | - | - |
 | USER/PASS | - | - | ✅ | - | - | - |
 | APOP | - | - | ✅ | - | - | - |
 | NTLM | ✅ | - | - | - | ✅ | - |

--- a/docs/protocols/smtp.md
+++ b/docs/protocols/smtp.md
@@ -52,7 +52,7 @@ gomailtest smtp teststarttls --host smtp.example.com --port 587 --tlsversion 1.3
 
 Connects, negotiates STARTTLS, then authenticates. Auto-selects the strongest available method when `--authmethod auto` (default).
 
-**Supported methods and auto-select priority:** `GSSAPI` → `CRAM-MD5` → `NTLM` → `PLAIN` → `LOGIN` (or `XOAUTH2` first when `--accesstoken` provided).
+**Supported methods and auto-select priority:** `GSSAPI` → `CRAM-MD5` → `NTLM` → `PLAIN` → `LOGIN` (or `XOAUTH2` → `OAUTHBEARER` first when `--accesstoken` provided).
 
 | Method | Use case | Credentials |
 |--------|----------|-------------|
@@ -62,6 +62,7 @@ Connects, negotiates STARTTLS, then authenticates. Auto-selects the strongest av
 | `PLAIN` | Standard username/password over TLS | `--username`, `--password` |
 | `LOGIN` | Legacy username/password (two-step) | `--username`, `--password` |
 | `XOAUTH2` | Microsoft 365, Google Workspace | `--username`, `--accesstoken` |
+| `OAUTHBEARER` | RFC 7628 SASL OAuth (Dovecot, modern servers); OAuth 2.0/2.1 tokens | `--username`, `--accesstoken` |
 
 ```powershell
 # Auto-detect (picks strongest advertised method)
@@ -90,6 +91,11 @@ gomailtest smtp testauth --host exchange.contoso.com --port 25 \
 # XOAUTH2 (Microsoft 365 / Google Workspace)
 gomailtest smtp testauth --host smtp.office365.com --port 587 \
   --username user@company.com --accesstoken "eyJ..."
+
+# OAUTHBEARER (RFC 7628 — Dovecot and other modern servers)
+# The same token works whether obtained via an OAuth 2.0 or OAuth 2.1 flow.
+gomailtest smtp testauth --host smtp.example.com --port 587 \
+  --username user@example.com --accesstoken "eyJ..." --authmethod OAUTHBEARER
 ```
 
 ### sendmail — End-to-End Email Sending
@@ -116,8 +122,8 @@ gomailtest smtp sendmail \
 | `--timeout` | Connection timeout (seconds) | `SMTPTIMEOUT` | 30 |
 | `--username` | SMTP username (`DOMAIN\user` for NTLM, `user@REALM` for GSSAPI) | `SMTPUSERNAME` | — |
 | `--password` | SMTP password | `SMTPPASSWORD` | — |
-| `--accesstoken` | OAuth2 bearer token for XOAUTH2 | `SMTPACCESSTOKEN` | — |
-| `--authmethod` | Auth method: PLAIN, LOGIN, CRAM-MD5, NTLM, GSSAPI, XOAUTH2, auto | `SMTPAUTHMETHOD` | auto |
+| `--accesstoken` | OAuth2 bearer token for XOAUTH2 or OAUTHBEARER | `SMTPACCESSTOKEN` | — |
+| `--authmethod` | Auth method: PLAIN, LOGIN, CRAM-MD5, NTLM, GSSAPI, XOAUTH2, OAUTHBEARER, auto | `SMTPAUTHMETHOD` | auto |
 | `--realm` | Kerberos realm for GSSAPI (auto-extracted from `user@REALM` if omitted) | `SMTPREALM` | — |
 | `--kdc` | KDC address for GSSAPI (uses DNS SRV if omitted) | `SMTPKDC` | — |
 | `--starttls` | Force STARTTLS usage | `SMTPSTARTTLS` | false |

--- a/internal/common/version/version.go
+++ b/internal/common/version/version.go
@@ -8,7 +8,7 @@ package version
 // 1. Change the Version constant below
 // 2. Create a changelog entry in ChangeLog/{version}.md
 // 3. Commit with message: "Bump version to {version}"
-const Version = "3.3.1"
+const Version = "3.3.8"
 
 // Get returns the current version string.
 // This is a convenience function for accessing the Version constant.

--- a/internal/protocols/smtp/config.go
+++ b/internal/protocols/smtp/config.go
@@ -24,8 +24,8 @@ type Config struct {
 	// Authentication
 	Username    string
 	Password    string
-	AccessToken string // OAuth2 access token for XOAUTH2 authentication
-	AuthMethod  string // PLAIN, LOGIN, CRAM-MD5, NTLM, GSSAPI, XOAUTH2, or "auto"
+	AccessToken string // OAuth2 bearer token for XOAUTH2 or OAUTHBEARER authentication
+	AuthMethod  string // PLAIN, LOGIN, CRAM-MD5, NTLM, GSSAPI, XOAUTH2, OAUTHBEARER, or "auto"
 	Realm       string // Kerberos realm for GSSAPI (auto-extracted from user@REALM if empty)
 	KDCAddress  string // KDC host:port override for GSSAPI (uses DNS SRV if empty)
 
@@ -97,8 +97,8 @@ func RegisterPersistentFlags(cmd *cobra.Command) {
 	// Authentication
 	f.String("username", "", "SMTP username for authentication (env: SMTPUSERNAME)")
 	f.String("password", "", "SMTP password for authentication (env: SMTPPASSWORD)")
-	f.String("accesstoken", "", "OAuth2 access token for XOAUTH2 authentication (env: SMTPACCESSTOKEN)")
-	f.String("authmethod", "auto", "Authentication method: PLAIN, LOGIN, CRAM-MD5, NTLM, GSSAPI, XOAUTH2, auto (env: SMTPAUTHMETHOD)")
+	f.String("accesstoken", "", "OAuth2 bearer token for XOAUTH2 or OAUTHBEARER authentication (env: SMTPACCESSTOKEN)")
+	f.String("authmethod", "auto", "Authentication method: PLAIN, LOGIN, CRAM-MD5, NTLM, GSSAPI, XOAUTH2, OAUTHBEARER, auto (env: SMTPAUTHMETHOD)")
 	f.String("realm", "", "Kerberos realm for GSSAPI (auto-extracted from user@REALM if omitted) (env: SMTPREALM)")
 	f.String("kdc", "", "KDC address override for GSSAPI (host or host:port; uses DNS SRV if omitted) (env: SMTPKDC)")
 
@@ -334,22 +334,23 @@ func validateConfiguration(config *Config) error {
 		if config.Username == "" {
 			return fmt.Errorf("testauth requires -username")
 		}
-		// XOAUTH2 requires accesstoken instead of password
-		if strings.EqualFold(config.AuthMethod, "XOAUTH2") {
+		// Token-based mechanisms (XOAUTH2, OAUTHBEARER) require accesstoken instead of password
+		if strings.EqualFold(config.AuthMethod, "XOAUTH2") || strings.EqualFold(config.AuthMethod, "OAUTHBEARER") {
+			method := strings.ToUpper(config.AuthMethod)
 			if config.AccessToken == "" {
-				return fmt.Errorf("XOAUTH2 authentication requires -accesstoken")
+				return fmt.Errorf("%s authentication requires -accesstoken", method)
 			}
 			if config.Password != "" {
-				fmt.Println("Warning: both -password and -accesstoken provided; -password will be ignored for XOAUTH2")
+				fmt.Printf("Warning: both -password and -accesstoken provided; -password will be ignored for %s\n", method)
 			}
 		} else if config.AccessToken != "" {
-			// If accesstoken provided, assume XOAUTH2
+			// If accesstoken provided, a token-based mechanism (XOAUTH2/OAUTHBEARER) is used
 			// No password required
 			if config.Password != "" {
-				fmt.Println("Warning: both -password and -accesstoken provided; -password will be ignored (using XOAUTH2)")
+				fmt.Println("Warning: both -password and -accesstoken provided; -password will be ignored (using token-based auth)")
 			}
 		} else if config.Password == "" {
-			return fmt.Errorf("testauth requires -password (or -accesstoken for XOAUTH2)")
+			return fmt.Errorf("testauth requires -password (or -accesstoken for XOAUTH2/OAUTHBEARER)")
 		}
 
 	case ActionSendMail:

--- a/internal/protocols/smtp/smtp_client.go
+++ b/internal/protocols/smtp/smtp_client.go
@@ -312,6 +312,8 @@ func (c *SMTPClient) Auth(username, password, accessToken string, mechanisms []s
 		auth = smtp.CRAMMD5Auth(username, password)
 	case "XOAUTH2":
 		auth = &xoauth2Auth{username, accessToken}
+	case "OAUTHBEARER":
+		auth = &oauthbearerAuth{username: username, accessToken: accessToken, host: c.host, port: c.port}
 	case "NTLM":
 		auth = &ntlmAuth{username: username, password: password}
 	case "GSSAPI":
@@ -483,7 +485,7 @@ func selectAuthMechanism(requested []string, available []string, hasAccessToken 
 	// Auto-select: prefer XOAUTH2 if access token provided, otherwise prefer stronger mechanisms
 	var preferenceOrder []string
 	if hasAccessToken {
-		preferenceOrder = []string{"XOAUTH2", "GSSAPI", "CRAM-MD5", "NTLM", "PLAIN", "LOGIN"}
+		preferenceOrder = []string{"XOAUTH2", "OAUTHBEARER", "GSSAPI", "CRAM-MD5", "NTLM", "PLAIN", "LOGIN"}
 	} else {
 		preferenceOrder = []string{"GSSAPI", "CRAM-MD5", "NTLM", "PLAIN", "LOGIN"}
 	}
@@ -556,6 +558,37 @@ func (a *xoauth2Auth) Start(server *smtp.ServerInfo) (string, []byte, error) {
 func (a *xoauth2Auth) Next(fromServer []byte, more bool) ([]byte, error) {
 	// XOAUTH2 is single-step, but server may send error JSON on failure
 	// Return empty to signal we have nothing more to send
+	return nil, nil
+}
+
+// oauthbearerAuth implements SASL OAUTHBEARER (RFC 7628). It carries an OAuth 2.0/2.1
+// bearer access token (the SASL layer is identical for both OAuth versions; only token
+// acquisition differs, which is out of scope here). Initial response (full form):
+//
+//	n,a=<user>,\x01host=<host>\x01port=<port>\x01auth=Bearer <token>\x01\x01
+//
+// The host/port and authzid are included for maximum server compatibility.
+type oauthbearerAuth struct {
+	username    string
+	accessToken string
+	host        string
+	port        int
+}
+
+func (a *oauthbearerAuth) Start(_ *smtp.ServerInfo) (string, []byte, error) {
+	resp := fmt.Sprintf("n,a=%s,\x01host=%s\x01port=%d\x01auth=Bearer %s\x01\x01",
+		a.username, a.host, a.port, a.accessToken)
+	return "OAUTHBEARER", []byte(resp), nil
+}
+
+func (a *oauthbearerAuth) Next(_ []byte, more bool) ([]byte, error) {
+	// On failure the server sends a base64 JSON error as a continuation (more=true).
+	// RFC 7628 §3.2.3 requires the client to send a single kvsep (\x01) dummy response so
+	// the server can finish the exchange with a clean SASL failure instead of leaving the
+	// state machine hanging. (XOAUTH2 returns nil here; OAUTHBEARER differs by sending it.)
+	if more {
+		return []byte("\x01"), nil
+	}
 	return nil, nil
 }
 

--- a/internal/protocols/smtp/smtp_client_test.go
+++ b/internal/protocols/smtp/smtp_client_test.go
@@ -439,6 +439,36 @@ func TestSelectAuthMechanism(t *testing.T) {
 			expected:       "CRAM-MD5",
 		},
 
+		// OAUTHBEARER (RFC 7628) selection
+		{
+			name:           "Prefer XOAUTH2 over OAUTHBEARER when both advertised",
+			requested:      []string{"auto"},
+			available:      []string{"LOGIN", "PLAIN", "OAUTHBEARER", "XOAUTH2"},
+			hasAccessToken: true,
+			expected:       "XOAUTH2",
+		},
+		{
+			name:           "Auto-select OAUTHBEARER when XOAUTH2 not advertised but token provided",
+			requested:      []string{"auto"},
+			available:      []string{"LOGIN", "PLAIN", "OAUTHBEARER"},
+			hasAccessToken: true,
+			expected:       "OAUTHBEARER",
+		},
+		{
+			name:           "Explicit OAUTHBEARER selection",
+			requested:      []string{"OAUTHBEARER"},
+			available:      []string{"LOGIN", "PLAIN", "OAUTHBEARER"},
+			hasAccessToken: true,
+			expected:       "OAUTHBEARER",
+		},
+		{
+			name:           "Explicit OAUTHBEARER not available returns empty",
+			requested:      []string{"OAUTHBEARER"},
+			available:      []string{"LOGIN", "PLAIN", "XOAUTH2"},
+			hasAccessToken: true,
+			expected:       "",
+		},
+
 		// Explicit mechanism selection
 		{
 			name:           "Explicit PLAIN selection",
@@ -664,6 +694,105 @@ func TestXOAUTH2Auth_Next(t *testing.T) {
 	}
 	if resp != nil {
 		t.Errorf("xoauth2Auth.Next() should return nil, got %v", resp)
+	}
+}
+
+// TestOAUTHBEARERAuth tests OAUTHBEARER (RFC 7628) initial response generation
+func TestOAUTHBEARERAuth(t *testing.T) {
+	tests := []struct {
+		name        string
+		username    string
+		accessToken string
+		host        string
+		port        int
+		wantContain []string
+	}{
+		{
+			name:        "Standard form",
+			username:    "user@example.com",
+			accessToken: "ya29.token123",
+			host:        "smtp.example.com",
+			port:        587,
+			wantContain: []string{"n,a=user@example.com,", "host=smtp.example.com", "port=587", "auth=Bearer ya29.token123"},
+		},
+		{
+			name:        "Microsoft 365 form",
+			username:    "user@company.onmicrosoft.com",
+			accessToken: "eyJ0eXAi.jwt.token",
+			host:        "smtp.office365.com",
+			port:        587,
+			wantContain: []string{"n,a=user@company.onmicrosoft.com,", "host=smtp.office365.com", "port=587", "auth=Bearer eyJ0eXAi.jwt.token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &oauthbearerAuth{
+				username:    tt.username,
+				accessToken: tt.accessToken,
+				host:        tt.host,
+				port:        tt.port,
+			}
+
+			mechanism, resp, err := auth.Start(nil)
+			if err != nil {
+				t.Fatalf("oauthbearerAuth.Start() error = %v", err)
+			}
+
+			if mechanism != "OAUTHBEARER" {
+				t.Errorf("oauthbearerAuth.Start() mechanism = %q, want OAUTHBEARER", mechanism)
+			}
+
+			respStr := string(resp)
+
+			// RFC 7628: must begin with the gs2-header "n,a=<user>,"
+			if !strings.HasPrefix(respStr, "n,a="+tt.username+",") {
+				t.Errorf("oauthbearerAuth.Start() response missing gs2-header prefix\ngot: %q", respStr)
+			}
+
+			for _, want := range tt.wantContain {
+				if !strings.Contains(respStr, want) {
+					t.Errorf("oauthbearerAuth.Start() response missing %q\ngot: %q", want, respStr)
+				}
+			}
+
+			// Verify SOH separators and the trailing double SOH
+			if !strings.Contains(respStr, "\x01") {
+				t.Error("oauthbearerAuth.Start() response missing SOH (\\x01) separators")
+			}
+			if !strings.HasSuffix(respStr, "\x01\x01") {
+				t.Error("oauthbearerAuth.Start() response should end with \\x01\\x01")
+			}
+		})
+	}
+}
+
+// TestOAUTHBEARERAuth_Next tests OAUTHBEARER failure handling (RFC 7628 §3.2.3)
+func TestOAUTHBEARERAuth_Next(t *testing.T) {
+	auth := &oauthbearerAuth{
+		username:    "user@example.com",
+		accessToken: "token123",
+		host:        "smtp.example.com",
+		port:        587,
+	}
+
+	// On a server error continuation (more=true), the client must send a single \x01 dummy
+	// so the exchange terminates cleanly with a SASL failure.
+	resp, err := auth.Next([]byte(`{"status":"invalid_token"}`), true)
+	if err != nil {
+		t.Errorf("oauthbearerAuth.Next() unexpected error = %v", err)
+	}
+	if string(resp) != "\x01" {
+		t.Errorf("oauthbearerAuth.Next(more=true) = %q, want \\x01", resp)
+	}
+
+	// With more=false there is nothing further to send.
+	resp, err = auth.Next(nil, false)
+	if err != nil {
+		t.Errorf("oauthbearerAuth.Next() unexpected error = %v", err)
+	}
+	if resp != nil {
+		t.Errorf("oauthbearerAuth.Next(more=false) should return nil, got %v", resp)
 	}
 }
 

--- a/migration/3.3.8_OAUTHBEARER_SMTP.md
+++ b/migration/3.3.8_OAUTHBEARER_SMTP.md
@@ -1,0 +1,83 @@
+# v3.3.8 — SASL OAUTHBEARER Authentication for SMTP
+
+## What Changed
+
+SASL **OAUTHBEARER** authentication (RFC 7628) is now supported for the `gomailtest smtp` commands (`testauth`, `sendmail`). This is the IETF standards-track OAuth SASL profile, complementing the existing legacy **XOAUTH2** mechanism. It enables testing servers that advertise `OAUTHBEARER` (e.g. Dovecot and other modern mail stacks) using a bearer access token.
+
+**No new dependency** — implemented against the stdlib `net/smtp` `smtp.Auth` interface, the same pattern as XOAUTH2/NTLM/GSSAPI. **No new flag** — reuses the existing `--accesstoken` / `SMTPACCESSTOKEN`.
+
+## OAuth 2.0 vs 2.1
+
+At the SASL/SMTP layer there is **no difference**. OAUTHBEARER carries an opaque bearer token (`auth=Bearer <token>`); OAuth 2.1 only changes how that token is *obtained* (mandatory PKCE, no implicit flow), which is outside this tool's scope. The tool consumes a pre-obtained, user-supplied token — exactly as XOAUTH2 does. A single OAUTHBEARER implementation therefore covers tokens issued by either an OAuth 2.0 or an OAuth 2.1 flow.
+
+## SASL Message Format
+
+OAUTHBEARER uses the full RFC 7628 initial client response (includes authzid + host + port for maximum server compatibility):
+
+```
+n,a=<username>,\x01host=<host>\x01port=<port>\x01auth=Bearer <token>\x01\x01
+```
+
+This differs from XOAUTH2, which uses the legacy `user=<email>\x01auth=Bearer <token>\x01\x01` form.
+
+**Failure handling (RFC 7628 §3.2.3):** on a failed exchange the server returns a base64 JSON error as a SASL continuation; the client replies with a single `\x01` (kvsep) dummy response so the server can complete the exchange with a clean SASL failure instead of leaving the state machine hanging. (XOAUTH2 returns nothing here — this is the one behavioral difference.)
+
+## Auto-Detection Priority Change
+
+When `--authmethod auto` (default), the new priority order is:
+
+**Without access token:** `GSSAPI` → `CRAM-MD5` → `NTLM` → `PLAIN` → `LOGIN` (unchanged)
+
+**With `--accesstoken`:** `XOAUTH2` → **`OAUTHBEARER`** → `GSSAPI` → `CRAM-MD5` → `NTLM` → `PLAIN` → `LOGIN`
+
+XOAUTH2 remains preferred (it is what Microsoft 365 / Google Workspace actually use). OAUTHBEARER is only selected when the server explicitly advertises it in the EHLO `AUTH` capability list and a token is present.
+
+## Flags
+
+No new flags. Selected via `--authmethod OAUTHBEARER`, token supplied via the existing `--accesstoken` / `SMTPACCESSTOKEN`.
+
+| Flag | Env var | Description |
+|------|---------|-------------|
+| `--authmethod` | `SMTPAUTHMETHOD` | now accepts `OAUTHBEARER` |
+| `--accesstoken` | `SMTPACCESSTOKEN` | bearer token for XOAUTH2 **and** OAUTHBEARER |
+
+## Example Usage
+
+```powershell
+# Explicit OAUTHBEARER
+gomailtest smtp testauth --host smtp.example.com --port 587 \
+  --username user@example.com --accesstoken "eyJ..." --authmethod OAUTHBEARER
+
+# Auto-detect (picks XOAUTH2 first, then OAUTHBEARER, when a token is present)
+gomailtest smtp testauth --host smtp.example.com --port 587 \
+  --username user@example.com --accesstoken "eyJ..."
+
+# Send via OAUTHBEARER-authenticated relay
+gomailtest smtp sendmail --host smtp.example.com --port 587 \
+  --username user@example.com --accesstoken "eyJ..." --authmethod OAUTHBEARER \
+  --from user@example.com --to bob@example.com \
+  --subject "Test" --body "OAUTHBEARER relay test"
+```
+
+The same `--accesstoken` value works whether the token was obtained via an OAuth 2.0 or OAuth 2.1 flow.
+
+## Files Modified
+
+- `internal/protocols/smtp/smtp_client.go` — added `oauthbearerAuth` type (full RFC 7628 initial response built from `c.host`/`c.port`; `Next` returns the `\x01` dummy on failure), added `OAUTHBEARER` case to `Auth()` switch, inserted `OAUTHBEARER` after `XOAUTH2` in `selectAuthMechanism` token-present priority
+- `internal/protocols/smtp/config.go` — added `OAUTHBEARER` to the `--authmethod` help text (no new field/flag; reuses `AccessToken`)
+- `internal/protocols/smtp/smtp_client_test.go` — added `TestOAUTHBEARERAuth`, `TestOAUTHBEARERAuth_Next`, and OAUTHBEARER cases in `TestSelectAuthMechanism`
+- `TOOLS.md` — added OAUTHBEARER row to authentication matrix
+- `docs/protocols/smtp.md` — updated auth method table, priority sentence, added OAUTHBEARER example and flag reference
+- `README.md` — added OAUTHBEARER quick-start example
+- `ChangeLog/` — added v3.3.7 entry
+
+## Verification
+
+1. `go build ./...` and `go vet ./...` — compiles clean.
+2. `go test ./internal/protocols/smtp/...` — new unit tests pass alongside existing ones.
+3. Optional live test against a server advertising `AUTH ... OAUTHBEARER`:
+   ```powershell
+   gomailtest smtp testauth --host <host> --port 587 \
+     --username user@example.com --accesstoken "<token>" --authmethod OAUTHBEARER --verbose
+   ```
+   Verbose output should show `Starting authentication with mechanism: OAUTHBEARER` and a `235` success (or a clean `535` SASL failure on a bad token rather than a hang, confirming the `Next` dummy-response handling).

--- a/migration/3.3.8_OAUTHBEARER_SMTP.md
+++ b/migration/3.3.8_OAUTHBEARER_SMTP.md
@@ -69,7 +69,7 @@ The same `--accesstoken` value works whether the token was obtained via an OAuth
 - `TOOLS.md` — added OAUTHBEARER row to authentication matrix
 - `docs/protocols/smtp.md` — updated auth method table, priority sentence, added OAUTHBEARER example and flag reference
 - `README.md` — added OAUTHBEARER quick-start example
-- `ChangeLog/` — added v3.3.7 entry
+- `ChangeLog/` — added v3.3.8 entry
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Adds **SASL OAUTHBEARER** (RFC 7628) authentication for the `gomailtest smtp` commands (`testauth`, `sendmail`), complementing the existing legacy **XOAUTH2** mechanism. Selected via `--authmethod OAUTHBEARER` and supplied with the existing `--accesstoken` / `SMTPACCESSTOKEN` — no new flag, no new dependency (built on the stdlib `net/smtp` `smtp.Auth` interface, same pattern as XOAUTH2/NTLM/GSSAPI).

**OAuth 2.0 vs 2.1:** identical at the SASL layer — OAUTHBEARER carries an opaque bearer token; only token *acquisition* differs (out of scope, as the tool consumes a pre-obtained token). A single implementation covers both.

## What's included

- **`oauthbearerAuth`** type in `internal/protocols/smtp/smtp_client.go`. Initial response uses the full RFC 7628 form for maximum server compatibility:
  ```
  n,a=<user>,\x01host=<host>\x01port=<port>\x01auth=Bearer <token>\x01\x01
  ```
- **Failure handling (RFC 7628 §3.2.3):** on a failed exchange the server sends a `334` error continuation; `Next` returns the single `\x01` kvsep dummy so the server emits its `535`. Without this, `net/smtp.Client.Auth` would break out with `err == nil` and **falsely report success** — this is the one behavioral difference from XOAUTH2.
- **Auto-select:** `OAUTHBEARER` slots in right after `XOAUTH2` when a token is present (XOAUTH2 stays preferred since that's what M365/Google actually use). Only chosen when the server advertises it.
- **Validation:** `testauth` token-based credential check generalized to cover both XOAUTH2 and OAUTHBEARER.
- **Docs:** `docs/protocols/smtp.md`, `README.md`, `TOOLS.md`, `ChangeLog/3.3.8.md`, `migration/3.3.8_OAUTHBEARER_SMTP.md`; version constant bumped `3.3.1` → `3.3.8`.

## Testing

- `go build ./...` and `go vet ./...` clean.
- `go test ./internal/protocols/smtp/...` passes, including new `TestOAUTHBEARERAuth`, `TestOAUTHBEARERAuth_Next`, and OAUTHBEARER cases in `TestSelectAuthMechanism` (preferred-after-XOAUTH2, auto/explicit selection, unavailable→empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)