### PR TITLE
Add exportmessages action to IMAP, POP3, and MS Graph protocols

### DIFF
--- a/docs/protocols/imap.md
+++ b/docs/protocols/imap.md
@@ -60,6 +60,30 @@ gomailtest imap listfolders --host imap.example.com --port 993 --imaps \
     --username user@example.com --password "yourpassword"
 ```
 
+### exportmessages — Export Matching Messages as .eml
+
+Authenticates, selects a mailbox, SEARCHes for messages by Message-ID and/or
+a Subject substring, and exports each match's full raw RFC822 message as a
+`.eml` file.
+
+```powershell
+gomailtest imap exportmessages --host imap.example.com --port 993 --imaps \
+    --username user@example.com --password "yourpassword" \
+    --subject "Invoice"
+
+gomailtest imap exportmessages --host imap.example.com --port 993 --imaps \
+    --username user@example.com --password "yourpassword" \
+    --messageid "<message-id@example.com>" --mailbox "INBOX" --count 10
+
+# Custom export directory
+gomailtest imap exportmessages --host imap.example.com --port 993 --imaps \
+    --username user@example.com --password "yourpassword" \
+    --subject "Invoice" --exportdir "C:\exports"
+```
+
+Output goes to `%TEMP%\export\{date}\msg_{uid}.eml`, or
+`<exportdir>\{date}\msg_{uid}.eml` when `--exportdir` is given.
+
 ## Flags
 
 | Flag | Description | Environment Variable | Default |
@@ -88,6 +112,16 @@ gomailtest imap listfolders --host imap.example.com --port 993 --imaps \
 | `--loglevel` | Log level: DEBUG, INFO, WARN, ERROR | — | INFO |
 | `--output` | Output format: text, json | `IMAPOUTPUT` | text |
 | `--logformat` | Log file format: csv, json | `IMAPLOGFORMAT` | csv |
+
+### exportmessages-specific
+
+| Flag | Description | Environment Variable | Default |
+|------|-------------|---------------------|---------|
+| `--messageid` | Message-ID header value to search for | `IMAPMESSAGEID` | — |
+| `--subject` | Subject substring to search for | `IMAPSUBJECT` | — |
+| `--mailbox` | Mailbox to search | `IMAPMAILBOX` | INBOX |
+| `--count` | Maximum number of matching messages to export | `IMAPCOUNT` | 25 |
+| `--exportdir` | Directory under which to create the dated export folder | `IMAPEXPORTDIR` | OS temp dir |
 
 **Note:** `--imaps` and `--starttls` cannot be used together. When `--imaps` is set and port is the default 143, the port automatically changes to 993. `--no-imaps`+`--imaps` and `--no-starttls`+`--starttls` are each mutually exclusive (useful to catch conflicting defaults from `--config`/env vars).
 

--- a/docs/protocols/msgraph.md
+++ b/docs/protocols/msgraph.md
@@ -127,6 +127,22 @@ Output goes to `%TEMP%\export\{date}\message_{n}_{timestamp}.json`.
 gomailtest msgraph searchandexport --messageid "<message-id@example.com>"
 ```
 
+### exportmessages — Export Matching Messages as .eml
+
+Searches messages by Internet Message-ID and/or a subject substring (OData
+`contains()`), then downloads each match's raw RFC822 content as a `.eml`
+file.
+
+```powershell
+gomailtest msgraph exportmessages --subject "Invoice"
+gomailtest msgraph exportmessages --messageid "<message-id@example.com>"
+gomailtest msgraph exportmessages --subject "Invoice" --count 10
+gomailtest msgraph exportmessages --subject "Invoice" --exportdir "C:\exports"
+```
+
+Output goes to `%TEMP%\export\{date}\msg_{id}.eml`, or
+`<exportdir>\{date}\msg_{id}.eml` when `--exportdir` is given.
+
 ## Flags
 
 ### Persistent (all subcommands)
@@ -167,6 +183,15 @@ gomailtest msgraph searchandexport --messageid "<message-id@example.com>"
 | `--start` | Start time (RFC3339) | `MSGRAPHSTART` |
 | `--end` | End time (RFC3339) | `MSGRAPHEND` |
 | `--messageid` | Internet Message ID | `MSGRAPHMESSAGEID` |
+| `--exportdir` | Directory under which to create the dated export folder (used by `exportinbox`, `searchandexport`, `exportmessages`) | `MSGRAPHEXPORTDIR` | OS temp dir |
+
+### exportmessages-specific
+
+| Flag | Description | Environment Variable | Default |
+|------|-------------|---------------------|---------|
+| `--messageid` | Internet Message-ID to search for | `MSGRAPHMESSAGEID` | — |
+| `--subject` | Subject substring to search for (OData `contains()`) | `MSGRAPHSUBJECT` | — |
+| `--count` | Maximum number of matching messages to export | `MSGRAPHCOUNT` | 25 |
 
 ## Authentication Methods
 
@@ -285,7 +310,7 @@ Retry uses exponential backoff: 2s → 4s → 8s → 16s → 30s (capped). Retri
 |--------|-----------|
 | sendmail | `Mail.Send` |
 | getevents, sendinvite | `Calendars.ReadWrite` |
-| getinbox, exportinbox, searchandexport | `Mail.Read` |
+| getinbox, exportinbox, searchandexport, exportmessages | `Mail.Read` |
 | getschedule | `Calendars.Read` |
 
 ## Tips and Best Practices

--- a/docs/protocols/pop3.md
+++ b/docs/protocols/pop3.md
@@ -65,6 +65,30 @@ gomailtest pop3 listmail --host pop.example.com --port 995 --pop3s \
     --username user@example.com --password "yourpassword" --maxmessages 50
 ```
 
+### exportmessages — Export Matching Messages as .eml
+
+Authenticates, fetches headers for each message via `TOP`, matches against the
+given Message-ID and/or Subject, and exports each match's full message (via
+`RETR`) as a `.eml` file.
+
+```powershell
+gomailtest pop3 exportmessages --host pop.example.com --port 995 --pop3s \
+    --username user@example.com --password "yourpassword" \
+    --subject "Invoice"
+
+gomailtest pop3 exportmessages --host pop.example.com --port 995 --pop3s \
+    --username user@example.com --password "yourpassword" \
+    --messageid "<message-id@example.com>" --count 10
+
+# Custom export directory
+gomailtest pop3 exportmessages --host pop.example.com --port 995 --pop3s \
+    --username user@example.com --password "yourpassword" \
+    --subject "Invoice" --exportdir "C:\exports"
+```
+
+Output goes to `%TEMP%\export\{date}\msg_{message-id}.eml`, or
+`<exportdir>\{date}\msg_{message-id}.eml` when `--exportdir` is given.
+
 ## Flags
 
 ### Persistent (all subcommands)
@@ -102,6 +126,15 @@ gomailtest pop3 listmail --host pop.example.com --port 995 --pop3s \
 | Flag | Description | Environment Variable | Default |
 |------|-------------|---------------------|---------|
 | `--maxmessages` | Maximum messages to list | `POP3MAXMESSAGES` | 100 |
+
+### exportmessages-specific
+
+| Flag | Description | Environment Variable | Default |
+|------|-------------|---------------------|---------|
+| `--messageid` | Message-ID header value to search for | `POP3MESSAGEID` | — |
+| `--subject` | Subject substring to search for | `POP3SUBJECT` | — |
+| `--count` | Maximum number of matching messages to export | `POP3COUNT` | 25 |
+| `--exportdir` | Directory under which to create the dated export folder | `POP3EXPORTDIR` | OS temp dir |
 
 ## Environment Variables
 

--- a/internal/common/export/export.go
+++ b/internal/common/export/export.go
@@ -1,0 +1,35 @@
+// Package export provides shared helpers for exporting messages to disk.
+package export
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CreateExportDir creates and returns the export directory:
+// <baseDir>/export/<YYYY-MM-DD>/. If baseDir is empty, the OS temp directory
+// is used, reproducing the default %TEMP%/export/<date>/ layout.
+func CreateExportDir(baseDir string) (string, error) {
+	if baseDir == "" {
+		baseDir = os.TempDir()
+	}
+	dateStr := time.Now().Format("2006-01-02")
+	dir := filepath.Join(baseDir, "export", dateStr)
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create export directory %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// SanitizeFilename replaces filesystem-unsafe characters with underscores.
+func SanitizeFilename(name string) string {
+	invalid := []string{"<", ">", ":", "\"", "/", "\\", "|", "?", "*", "="}
+	for _, char := range invalid {
+		name = strings.ReplaceAll(name, char, "_")
+	}
+	return name
+}

--- a/internal/jmap/protocol/methods.go
+++ b/internal/jmap/protocol/methods.go
@@ -188,6 +188,59 @@ func NewEmailQueryRequest(accountId Id, filter interface{}, limit uint32) *Reque
 	}
 }
 
+// NewEmailGetRequest creates a request to get emails by ID with the given properties.
+func NewEmailGetRequest(accountId Id, ids []Id, properties []string) *Request {
+	return &Request{
+		Using: []string{CoreCapability, MailCapability},
+		MethodCalls: []MethodCall{
+			{
+				Name: MethodEmailGet,
+				Arguments: GetRequest{
+					AccountId:  accountId,
+					Ids:        ids,
+					Properties: properties,
+				},
+				CallId: "0",
+			},
+		},
+	}
+}
+
+// ParseEmailGetResponse parses an Email/get response.
+func ParseEmailGetResponse(resp *MethodResponse) (*GetEmailsResponse, error) {
+	var result GetEmailsResponse
+	if err := json.Unmarshal(resp.Arguments, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// BuildEmailSearchFilter builds an Email/query filter (RFC 8621 §4.4.1) that
+// matches the given Message-ID header value and/or subject substring. At
+// least one of messageID/subject must be non-empty. When both are given, the
+// resulting filter requires both conditions (AND).
+func BuildEmailSearchFilter(messageID, subject string) map[string]interface{} {
+	var conditions []map[string]interface{}
+	if messageID != "" {
+		conditions = append(conditions, map[string]interface{}{
+			"header": []string{"Message-ID", messageID},
+		})
+	}
+	if subject != "" {
+		conditions = append(conditions, map[string]interface{}{
+			"subject": subject,
+		})
+	}
+
+	if len(conditions) == 1 {
+		return conditions[0]
+	}
+	return map[string]interface{}{
+		"operator":   "AND",
+		"conditions": conditions,
+	}
+}
+
 // ParseMailboxGetResponse parses a Mailbox/get response.
 func ParseMailboxGetResponse(resp *MethodResponse) (*GetMailboxesResponse, error) {
 	var result GetMailboxesResponse

--- a/internal/protocols/imap/cmd.go
+++ b/internal/protocols/imap/cmd.go
@@ -32,6 +32,7 @@ Environment variables use the IMAP prefix (e.g. IMAPHOST, IMAPPORT, IMAPUSERNAME
 		newTestConnectCmd(v),
 		newTestAuthCmd(v),
 		newListFoldersCmd(v),
+		newExportMessagesCmd(v),
 	)
 
 	return cmd
@@ -126,6 +127,58 @@ Use --starttls or --imaps to establish TLS before authenticating.`,
 			return nil
 		},
 	}
+}
+
+func newExportMessagesCmd(v *viper.Viper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exportmessages",
+		Short: "Search messages by Message-ID and/or Subject and export them as .eml files",
+		Long: `Authenticate to the IMAP server, SEARCH the selected mailbox for messages
+matching the given Message-ID and/or Subject, and export each match's full
+raw RFC822 message as a .eml file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = v.BindPFlags(cmd.Flags())
+			_ = v.BindPFlags(cmd.InheritedFlags())
+
+			if err := bootstrap.LoadConfigFile(v, v.GetString("config")); err != nil {
+				return err
+			}
+
+			config := ConfigFromViper(v)
+			config.Action = ActionExportMessages
+
+			if err := validateConfiguration(config); err != nil {
+				return fmt.Errorf("validation failed: %w\n\nRun '%s --help' for usage", err, cmd.CommandPath())
+			}
+
+			ctx, cancel := bootstrap.SetupSignalContext()
+			defer cancel()
+
+			slogger, csvLogger, logErr := bootstrap.InitLoggers("imaptool", ActionExportMessages, config.VerboseMode, config.LogLevel, config.LogFormat)
+			if logErr != nil {
+				slogger.Warn("Could not initialize file logging", "error", logErr)
+			}
+			if csvLogger != nil {
+				defer csvLogger.Close()
+			}
+
+			logger.LogInfo(slogger, "IMAP Connectivity Testing Tool started", "action", config.Action, "host", config.Host, "port", config.Port)
+
+			if err := exportMessages(ctx, config, csvLogger, slogger); err != nil {
+				logger.LogError(slogger, "Action failed", "error", err)
+				return err
+			}
+
+			logger.LogInfo(slogger, "Action completed successfully")
+			return nil
+		},
+	}
+	cmd.Flags().String("messageid", "", "Message-ID header value to search for (env: IMAPMESSAGEID)")
+	cmd.Flags().String("subject", "", "Subject substring to search for (env: IMAPSUBJECT)")
+	cmd.Flags().String("mailbox", "INBOX", "Mailbox to search (env: IMAPMAILBOX)")
+	cmd.Flags().Int("count", 25, "Maximum number of matching messages to export (env: IMAPCOUNT)")
+	cmd.Flags().String("exportdir", "", "Directory under which to create the dated export folder; defaults to the OS temp directory (env: IMAPEXPORTDIR)")
+	return cmd
 }
 
 func newListFoldersCmd(v *viper.Viper) *cobra.Command {

--- a/internal/protocols/imap/config.go
+++ b/internal/protocols/imap/config.go
@@ -50,13 +50,21 @@ type Config struct {
 	OutputFormat string
 	LogFormat    string  // Log file format: csv, json
 	RateLimit    float64 // Maximum requests per second (0 = unlimited)
+
+	// exportmessages configuration
+	Subject   string // Subject substring to search for
+	MessageID string // Message-ID header to search for
+	Mailbox   string // Mailbox to search (default: INBOX)
+	Count     int    // Maximum number of matching messages to export
+	ExportDir string // Directory under which to create the dated export folder (default: OS temp dir)
 }
 
 // Action constants
 const (
-	ActionTestConnect = "testconnect"
-	ActionTestAuth    = "testauth"
-	ActionListFolders = "listfolders"
+	ActionTestConnect    = "testconnect"
+	ActionTestAuth       = "testauth"
+	ActionListFolders    = "listfolders"
+	ActionExportMessages = "exportmessages"
 )
 
 // NewConfig creates a new Config with default values.
@@ -76,6 +84,8 @@ func NewConfig() *Config {
 		OutputFormat: "text",
 		LogFormat:    "csv",
 		RateLimit:    0,
+		Mailbox:      "INBOX",
+		Count:        25,
 	}
 }
 
@@ -145,6 +155,11 @@ func BindEnvs(v *viper.Viper) {
 		"output":      "IMAPOUTPUT",
 		"logformat":   "IMAPLOGFORMAT",
 		"ratelimit":   "IMAPRATELIMIT",
+		"subject":     "IMAPSUBJECT",
+		"messageid":   "IMAPMESSAGEID",
+		"mailbox":     "IMAPMAILBOX",
+		"count":       "IMAPCOUNT",
+		"exportdir":   "IMAPEXPORTDIR",
 	}
 	for key, env := range bindings {
 		_ = v.BindEnv(key, env)
@@ -201,6 +216,16 @@ func ConfigFromViper(v *viper.Viper) *Config {
 		logFormat = defaults.LogFormat
 	}
 
+	mailbox := v.GetString("mailbox")
+	if mailbox == "" {
+		mailbox = defaults.Mailbox
+	}
+
+	count := v.GetInt("count")
+	if count <= 0 {
+		count = defaults.Count
+	}
+
 	return &Config{
 		Host:           v.GetString("host"),
 		Port:           port,
@@ -226,13 +251,18 @@ func ConfigFromViper(v *viper.Viper) *Config {
 		OutputFormat:   outputFormat,
 		LogFormat:      logFormat,
 		RateLimit:      v.GetFloat64("ratelimit"),
+		Subject:        v.GetString("subject"),
+		MessageID:      v.GetString("messageid"),
+		Mailbox:        mailbox,
+		Count:          count,
+		ExportDir:      v.GetString("exportdir"),
 	}
 }
 
 // validateConfiguration validates the configuration.
 func validateConfiguration(config *Config) error {
 	// Validate action
-	validActions := []string{ActionTestConnect, ActionTestAuth, ActionListFolders}
+	validActions := []string{ActionTestConnect, ActionTestAuth, ActionListFolders, ActionExportMessages}
 	valid := false
 	for _, a := range validActions {
 		if config.Action == a {
@@ -307,7 +337,7 @@ func validateConfiguration(config *Config) error {
 
 	// Action-specific validation
 	switch config.Action {
-	case ActionTestAuth, ActionListFolders:
+	case ActionTestAuth, ActionListFolders, ActionExportMessages:
 		if config.Username == "" {
 			return fmt.Errorf("%s requires --username", config.Action)
 		}
@@ -324,6 +354,13 @@ func validateConfiguration(config *Config) error {
 			}
 		} else if config.Password == "" {
 			return fmt.Errorf("%s requires --password (or --accesstoken for XOAUTH2)", config.Action)
+		}
+	}
+
+	// Validate exportmessages-specific requirements
+	if config.Action == ActionExportMessages {
+		if config.MessageID == "" && strings.TrimSpace(config.Subject) == "" {
+			return fmt.Errorf("exportmessages action requires --messageid and/or --subject parameter")
 		}
 	}
 

--- a/internal/protocols/imap/exportmessages.go
+++ b/internal/protocols/imap/exportmessages.go
@@ -1,0 +1,137 @@
+package imap
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ziembor/gomailtesttool/internal/common/export"
+	"github.com/ziembor/gomailtesttool/internal/common/logger"
+)
+
+// exportMessages searches the configured mailbox for messages matching
+// config.MessageID and/or config.Subject and exports each match as a raw
+// .eml (RFC822) file.
+func exportMessages(ctx context.Context, config *Config, csvLogger logger.Logger, slogLogger *slog.Logger) error {
+	fmt.Printf("Searching %s on %s:%d for matching messages...\n", config.Mailbox, config.Host, config.Port)
+
+	columns := []string{"Action", "Status", "Server", "Port", "Mailbox", "Subject", "UID", "Filename", "Error"}
+	if shouldWrite, _ := csvLogger.ShouldWriteHeader(); shouldWrite {
+		if err := csvLogger.WriteHeader(columns); err != nil {
+			logger.LogError(slogLogger, "Failed to write CSV header", "error", err)
+		}
+	}
+
+	client := NewIMAPClient(config)
+
+	if err := client.Connect(ctx); err != nil {
+		logger.LogError(slogLogger, "Connection failed", "error", err, "host", config.Host, "port", config.Port)
+		writeExportRow(csvLogger, slogLogger, config, false, "", "", err.Error())
+		return fmt.Errorf("connection failed: %w", err)
+	}
+	defer func() { _ = client.Logout() }()
+
+	fmt.Printf("✓ Connected to %s:%d\n", config.Host, config.Port)
+
+	caps := client.GetCapabilities()
+	authMethod := config.AuthMethod
+	if strings.EqualFold(authMethod, "auto") {
+		if config.AccessToken != "" {
+			if caps != nil && caps.SupportsXOAUTH2() {
+				authMethod = "XOAUTH2"
+			} else {
+				authMethod = "PLAIN"
+			}
+		} else if caps != nil && caps.SupportsPlain() {
+			authMethod = "PLAIN"
+		} else {
+			authMethod = "LOGIN"
+		}
+	}
+
+	var authErr error
+	if config.AccessToken != "" && strings.EqualFold(authMethod, "XOAUTH2") {
+		authErr = client.Auth(ctx, config.Username, "", config.AccessToken)
+	} else {
+		authErr = client.Auth(ctx, config.Username, config.Password, "")
+	}
+	if authErr != nil {
+		logger.LogError(slogLogger, "Authentication failed", "error", authErr, "username", maskUsername(config.Username))
+		writeExportRow(csvLogger, slogLogger, config, false, "", "", fmt.Sprintf("Auth failed: %v", authErr))
+		return fmt.Errorf("authentication failed: %w", authErr)
+	}
+	fmt.Println("✓ Authentication successful")
+
+	if err := client.SelectMailbox(ctx, config.Mailbox); err != nil {
+		logger.LogError(slogLogger, "SELECT failed", "error", err, "mailbox", config.Mailbox)
+		writeExportRow(csvLogger, slogLogger, config, false, "", "", err.Error())
+		return err
+	}
+
+	uids, err := client.SearchMessages(ctx, config.MessageID, config.Subject)
+	if err != nil {
+		logger.LogError(slogLogger, "SEARCH failed", "error", err)
+		writeExportRow(csvLogger, slogLogger, config, false, "", "", err.Error())
+		return err
+	}
+
+	if len(uids) == 0 {
+		fmt.Println("No messages found matching the given criteria.")
+		writeExportRow(csvLogger, slogLogger, config, true, "", "", "No messages found (0 messages)")
+		return nil
+	}
+
+	if len(uids) > config.Count {
+		uids = uids[:config.Count]
+	}
+
+	exportDir, err := export.CreateExportDir(config.ExportDir)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Export directory: %s\n", exportDir)
+
+	successCount := 0
+	for _, uid := range uids {
+		uidStr := fmt.Sprintf("%d", uid)
+
+		body, err := client.FetchRFC822(ctx, uid)
+		if err != nil {
+			logger.LogError(slogLogger, "FETCH failed", "error", err, "uid", uint32(uid))
+			writeExportRow(csvLogger, slogLogger, config, false, uidStr, "", err.Error())
+			continue
+		}
+
+		filename := fmt.Sprintf("msg_%s.eml", export.SanitizeFilename(uidStr))
+		filePath := filepath.Join(exportDir, filename)
+		if err := os.WriteFile(filePath, body, 0644); err != nil {
+			logger.LogError(slogLogger, "Failed to write EML file", "error", err, "uid", uint32(uid))
+			writeExportRow(csvLogger, slogLogger, config, false, uidStr, "", err.Error())
+			continue
+		}
+
+		successCount++
+		fmt.Printf("Successfully exported UID %d -> %s\n", uid, filePath)
+		writeExportRow(csvLogger, slogLogger, config, true, uidStr, filePath, "")
+	}
+
+	fmt.Printf("Successfully exported %d/%d messages.\n", successCount, len(uids))
+	return nil
+}
+
+// writeExportRow writes a single CSV row for the exportmessages action.
+func writeExportRow(csvLogger logger.Logger, slogLogger *slog.Logger, config *Config, success bool, uid, filename, errStr string) {
+	status := "FAILURE"
+	if success {
+		status = "SUCCESS"
+	}
+	if logErr := csvLogger.WriteRow([]string{
+		ActionExportMessages, status, config.Host, fmt.Sprintf("%d", config.Port),
+		config.Mailbox, config.Subject, uid, filename, errStr,
+	}); logErr != nil {
+		logger.LogError(slogLogger, "Failed to write CSV row", "error", logErr)
+	}
+}

--- a/internal/protocols/imap/imap_client.go
+++ b/internal/protocols/imap/imap_client.go
@@ -245,6 +245,81 @@ func (c *IMAPClient) ListMailboxes(ctx context.Context) ([]MailboxInfo, error) {
 	return result, nil
 }
 
+// SelectMailbox selects (opens) the given mailbox for subsequent SEARCH/FETCH commands.
+func (c *IMAPClient) SelectMailbox(ctx context.Context, mailbox string) error {
+	if c.limiter != nil {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return fmt.Errorf("rate limit wait: %w", err)
+		}
+	}
+
+	if _, err := c.client.Select(mailbox, nil).Wait(); err != nil {
+		return fmt.Errorf("SELECT %s failed: %w", mailbox, err)
+	}
+	return nil
+}
+
+// SearchMessages searches the selected mailbox for messages matching the
+// given Message-ID header and/or a subject substring. At least one of
+// messageID/subject must be non-empty. Returns matching UIDs.
+func (c *IMAPClient) SearchMessages(ctx context.Context, messageID, subject string) ([]imap.UID, error) {
+	if c.limiter != nil {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limit wait: %w", err)
+		}
+	}
+
+	criteria := &imap.SearchCriteria{}
+	if messageID != "" {
+		criteria.Header = append(criteria.Header, imap.SearchCriteriaHeaderField{Key: "Message-Id", Value: messageID})
+	}
+	if subject != "" {
+		criteria.Header = append(criteria.Header, imap.SearchCriteriaHeaderField{Key: "Subject", Value: subject})
+	}
+
+	data, err := c.client.UIDSearch(criteria, nil).Wait()
+	if err != nil {
+		return nil, fmt.Errorf("SEARCH failed: %w", err)
+	}
+
+	uidSet, ok := data.All.(imap.UIDSet)
+	if !ok {
+		return nil, nil
+	}
+	uids, _ := uidSet.Nums()
+	return uids, nil
+}
+
+// FetchRFC822 fetches the full raw RFC822 message body for the given UID.
+func (c *IMAPClient) FetchRFC822(ctx context.Context, uid imap.UID) ([]byte, error) {
+	if c.limiter != nil {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limit wait: %w", err)
+		}
+	}
+
+	fetchCmd := c.client.Fetch(imap.UIDSetNum(uid), &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{}},
+	})
+	defer fetchCmd.Close()
+
+	msg := fetchCmd.Next()
+	if msg == nil {
+		return nil, fmt.Errorf("no message returned for UID %d", uid)
+	}
+
+	buf, err := msg.Collect()
+	if err != nil {
+		return nil, fmt.Errorf("FETCH failed for UID %d: %w", uid, err)
+	}
+
+	body := buf.FindBodySection(&imap.FetchItemBodySection{})
+	if body == nil {
+		return nil, fmt.Errorf("no body section returned for UID %d", uid)
+	}
+	return body, nil
+}
+
 // Logout sends the LOGOUT command and closes the connection.
 func (c *IMAPClient) Logout() error {
 	if c.client != nil {

--- a/internal/protocols/msgraph/cmd.go
+++ b/internal/protocols/msgraph/cmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ziembor/gomailtesttool/internal/common/bootstrap"
 )
 
-// NewCmd returns the "msgraph" cobra.Command with all 7 action subcommands.
+// NewCmd returns the "msgraph" cobra.Command with all 8 action subcommands.
 // Each subcommand shares persistent flags (auth, mailbox, output) and adds
 // its own action-specific flags.
 func NewCmd() *cobra.Command {
@@ -38,6 +38,7 @@ Authentication methods: --secret (client secret), --pfx (certificate file),
 		newGetScheduleCmd(v),
 		newExportInboxCmd(v),
 		newSearchAndExportCmd(v),
+		newExportMessagesCmd(v),
 	)
 
 	return cmd
@@ -359,6 +360,7 @@ func newExportInboxCmd(v *viper.Viper) *cobra.Command {
 		},
 	}
 	cmd.Flags().Int("count", 3, "Number of messages to export (env: MSGRAPHCOUNT)")
+	cmd.Flags().String("exportdir", "", "Directory under which to create the dated export folder; defaults to the OS temp directory (env: MSGRAPHEXPORTDIR)")
 	return cmd
 }
 
@@ -406,5 +408,60 @@ func newSearchAndExportCmd(v *viper.Viper) *cobra.Command {
 		},
 	}
 	cmd.Flags().String("messageid", "", "Internet Message-ID to search for (env: MSGRAPHMESSAGEID)")
+	cmd.Flags().String("exportdir", "", "Directory under which to create the dated export folder; defaults to the OS temp directory (env: MSGRAPHEXPORTDIR)")
+	return cmd
+}
+
+func newExportMessagesCmd(v *viper.Viper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exportmessages",
+		Short: "Search messages by Message-ID and/or Subject and export them as .eml files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = v.BindPFlags(cmd.Flags())
+			_ = v.BindPFlags(cmd.InheritedFlags())
+
+			if err := bootstrap.LoadConfigFile(v, v.GetString("config")); err != nil {
+				return err
+			}
+
+			config := ConfigFromViper(v)
+			config.Action = ActionExportMessages
+			// "subject" is shared with sendmail/sendinvite, whose default
+			// ("Automated Tool Notification") would otherwise narrow the
+			// search; only use it here if the user actually provided it.
+			config.Subject = v.GetString("subject")
+
+			if err := validateConfiguration(config); err != nil {
+				return fmt.Errorf("validation failed: %w", err)
+			}
+
+			ctx, cancel := bootstrap.SetupSignalContext()
+			defer cancel()
+
+			slogger, csvLogger, logErr := bootstrap.InitLoggers("msgraphtool", ActionExportMessages, config.VerboseMode, config.LogLevel, config.LogFormat)
+			if logErr != nil {
+				slogger.Warn("Could not initialize file logging", "error", logErr)
+			}
+			if csvLogger != nil {
+				defer csvLogger.Close()
+			}
+
+			if config.ProxyURL != "" {
+				os.Setenv("HTTP_PROXY", config.ProxyURL)
+				os.Setenv("HTTPS_PROXY", config.ProxyURL)
+			}
+
+			client, err := NewGraphServiceClient(ctx, config, slogger)
+			if err != nil {
+				return err
+			}
+
+			return exportMessages(ctx, client, config.Mailbox, config.MessageID, config.Subject, config.Count, config, csvLogger)
+		},
+	}
+	cmd.Flags().String("messageid", "", "Internet Message-ID to search for (env: MSGRAPHMESSAGEID)")
+	cmd.Flags().String("subject", "", "Subject substring to search for, used with OData contains() (env: MSGRAPHSUBJECT)")
+	cmd.Flags().Int("count", 25, "Maximum number of matching messages to export (env: MSGRAPHCOUNT)")
+	cmd.Flags().String("exportdir", "", "Directory under which to create the dated export folder; defaults to the OS temp directory (env: MSGRAPHEXPORTDIR)")
 	return cmd
 }

--- a/internal/protocols/msgraph/config.go
+++ b/internal/protocols/msgraph/config.go
@@ -49,7 +49,10 @@ type Config struct {
 	EndTime       string // End time in RFC3339 format
 
 	// Search configuration
-	MessageID string // Internet Message ID for searchandexport action
+	MessageID string // Internet Message ID for searchandexport/exportmessages actions
+
+	// Export configuration
+	ExportDir string // Directory under which to create the dated export folder (default: OS temp dir)
 
 	// Network configuration
 	ProxyURL   string        // HTTP/HTTPS proxy URL (e.g., http://proxy.example.com:8080)
@@ -92,6 +95,7 @@ const (
 	ActionGetSchedule     = "getschedule"
 	ActionExportInbox     = "exportinbox"
 	ActionSearchAndExport = "searchandexport"
+	ActionExportMessages  = "exportmessages"
 )
 
 // RegisterPersistentFlags registers flags shared by all msgraph subcommands
@@ -148,6 +152,7 @@ func BindEnvs(v *viper.Viper) {
 		"start":              "MSGRAPHSTART",
 		"end":                "MSGRAPHEND",
 		"messageid":          "MSGRAPHMESSAGEID",
+		"exportdir":          "MSGRAPHEXPORTDIR",
 		"proxy":              "MSGRAPHPROXY",
 		"maxretries":         "MSGRAPHMAXRETRIES",
 		"retrydelay":         "MSGRAPHRETRYDELAY",
@@ -235,6 +240,7 @@ func ConfigFromViper(v *viper.Viper) *Config {
 		StartTime:             v.GetString("start"),
 		EndTime:               v.GetString("end"),
 		MessageID:             v.GetString("messageid"),
+		ExportDir:             v.GetString("exportdir"),
 		ProxyURL:              v.GetString("proxy"),
 		MaxRetries:            maxRetries,
 		RetryDelay:            time.Duration(retryDelayMs) * time.Millisecond,
@@ -382,6 +388,26 @@ func validateConfiguration(config *Config) error {
 		// SECURITY: Validate Message-ID format to prevent OData injection attacks
 		if err := validateMessageID(config.MessageID); err != nil {
 			return fmt.Errorf("invalid message ID: %w", err)
+		}
+	}
+
+	// Validate exportmessages-specific requirements
+	if config.Action == ActionExportMessages {
+		if config.MessageID == "" && strings.TrimSpace(config.Subject) == "" {
+			return fmt.Errorf("exportmessages action requires --messageid and/or --subject parameter")
+		}
+
+		if config.MessageID != "" {
+			// SECURITY: Validate Message-ID format to prevent OData injection attacks
+			if err := validateMessageID(config.MessageID); err != nil {
+				return fmt.Errorf("invalid message ID: %w", err)
+			}
+		}
+
+		if config.Subject != "" {
+			if err := validateSearchSubject(config.Subject); err != nil {
+				return fmt.Errorf("invalid subject: %w", err)
+			}
 		}
 	}
 

--- a/internal/protocols/msgraph/handlers.go
+++ b/internal/protocols/msgraph/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/ziembor/gomailtesttool/internal/common/email"
+	"github.com/ziembor/gomailtesttool/internal/common/export"
 	"github.com/ziembor/gomailtesttool/internal/common/logger"
 )
 
@@ -591,7 +592,7 @@ func exportInbox(ctx context.Context, client *msgraphsdk.GraphServiceClient, mai
 	}
 
 	// Create export directory
-	exportDir, err := createExportDir()
+	exportDir, err := export.CreateExportDir(config.ExportDir)
 	if err != nil {
 		return err
 	}
@@ -674,7 +675,7 @@ func searchAndExport(ctx context.Context, client *msgraphsdk.GraphServiceClient,
 	}
 
 	// Create export directory
-	exportDir, err := createExportDir()
+	exportDir, err := export.CreateExportDir(config.ExportDir)
 	if err != nil {
 		return err
 	}
@@ -697,6 +698,147 @@ func searchAndExport(ctx context.Context, client *msgraphsdk.GraphServiceClient,
 	}
 
 	return nil
+}
+
+// exportMessages searches for messages matching the given Internet Message-ID
+// and/or subject pattern and exports each match as a raw .eml (RFC822) file.
+func exportMessages(ctx context.Context, client *msgraphsdk.GraphServiceClient, mailbox string, messageID string, subject string, count int, config *Config, logger logger.Logger) error {
+	// Build OData filter from the supplied criteria.
+	// SECURITY: Escape single quotes for OData filter (defense-in-depth);
+	// validateMessageID()/validateSearchSubject() already reject control
+	// characters and (for messageID) quotes.
+	var clauses []string
+	if messageID != "" {
+		escapedMessageID := strings.ReplaceAll(messageID, "'", "''")
+		clauses = append(clauses, fmt.Sprintf("internetMessageId eq '%s'", escapedMessageID))
+	}
+	if subject != "" {
+		escapedSubject := strings.ReplaceAll(subject, "'", "''")
+		clauses = append(clauses, fmt.Sprintf("contains(subject,'%s')", escapedSubject))
+	}
+	filter := strings.Join(clauses, " and ")
+
+	requestConfig := &users.ItemMessagesRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.ItemMessagesRequestBuilderGetQueryParameters{
+			Filter: &filter,
+			Top:    Int32Ptr(int32(count)),
+			Select: []string{"id", "internetMessageId", "subject", "receivedDateTime", "from", "toRecipients", "ccRecipients", "bccRecipients", "hasAttachments"},
+		},
+	}
+
+	logVerbose(config.VerboseMode, "Calling Graph API: GET /users/%s/messages?$filter=%s&$top=%d", mailbox, filter, count)
+
+	// Execute API call with retry logic
+	var getValueFunc func() []models.Messageable
+	err := retryWithBackoff(ctx, config.MaxRetries, config.RetryDelay, func() error {
+		apiResult, apiErr := client.Users().ByUserId(mailbox).Messages().Get(ctx, requestConfig)
+		if apiErr == nil {
+			getValueFunc = apiResult.GetValue
+		}
+		return apiErr
+	})
+
+	if err != nil {
+		enrichedErr := enrichGraphAPIError(err, logger, "exportMessages")
+		return fmt.Errorf("error searching messages for %s: %w", mailbox, enrichedErr)
+	}
+
+	messages := getValueFunc()
+	messageCount := len(messages)
+
+	logVerbose(config.VerboseMode, "API response received: %d messages", messageCount)
+
+	if messageCount == 0 {
+		if config.OutputFormat == "json" {
+			printJSON([]interface{}{}) // Empty array
+		} else {
+			fmt.Println("No messages found matching the given criteria.")
+		}
+		if logger != nil {
+			_ = logger.WriteRow([]string{ActionExportMessages, StatusSuccess, mailbox, "No messages found (0 messages)", "N/A"})
+		}
+		return nil
+	}
+
+	// Print JSON output if requested
+	if config.OutputFormat == "json" {
+		printJSON(formatMessagesOutput(messages))
+	}
+
+	// Create export directory
+	exportDir, err := export.CreateExportDir(config.ExportDir)
+	if err != nil {
+		return err
+	}
+
+	if config.OutputFormat != "json" {
+		fmt.Printf("Export directory: %s\n", exportDir)
+	}
+
+	successCount := 0
+	for _, message := range messages {
+		filePath, err := exportMessageToEML(ctx, client, mailbox, message, exportDir, config)
+		if err != nil {
+			log.Printf("Error exporting message ID %s: %v", *message.GetId(), err)
+			if logger != nil {
+				_ = logger.WriteRow([]string{ActionExportMessages, StatusError, mailbox, err.Error(), *message.GetId()})
+			}
+			continue
+		}
+
+		successCount++
+		if config.OutputFormat != "json" {
+			fmt.Printf("Successfully exported message: %s -> %s\n", *message.GetSubject(), filePath)
+		}
+		if logger != nil {
+			_ = logger.WriteRow([]string{ActionExportMessages, StatusSuccess, mailbox, "Exported successfully", *message.GetId(), filePath})
+		}
+	}
+
+	if config.OutputFormat != "json" {
+		fmt.Printf("Successfully exported %d/%d messages.\n", successCount, messageCount)
+	}
+
+	return nil
+}
+
+// exportMessageToEML fetches a message's raw RFC822/MIME content via the
+// Graph API "$value" endpoint and writes it to a .eml file in dir. It returns
+// the path to the written file.
+func exportMessageToEML(ctx context.Context, client *msgraphsdk.GraphServiceClient, mailbox string, message models.Messageable, dir string, config *Config) (string, error) {
+	if message.GetId() == nil {
+		return "", fmt.Errorf("message has no ID")
+	}
+	id := *message.GetId()
+
+	var mimeContent []byte
+	err := retryWithBackoff(ctx, config.MaxRetries, config.RetryDelay, func() error {
+		content, apiErr := client.Users().ByUserId(mailbox).Messages().ByMessageId(id).Content().Get(ctx, nil)
+		if apiErr == nil {
+			mimeContent = content
+		}
+		return apiErr
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch message content: %w", err)
+	}
+
+	// Prefer the Internet Message-ID for the filename when available, since
+	// it's more useful for cross-referencing than the Graph-internal ID.
+	name := id
+	if message.GetInternetMessageId() != nil && *message.GetInternetMessageId() != "" {
+		name = *message.GetInternetMessageId()
+	}
+
+	filename := fmt.Sprintf("msg_%s.eml", export.SanitizeFilename(name))
+	filePath := filepath.Join(dir, filename)
+
+	if err := os.WriteFile(filePath, mimeContent, 0644); err != nil {
+		return "", fmt.Errorf("failed to write EML file: %w", err)
+	}
+
+	logVerbose(config.VerboseMode, "Exported message to %s", filePath)
+	return filePath, nil
 }
 
 // exportMessageToJSON serializes a message to JSON and saves it to a file
@@ -758,7 +900,7 @@ func exportMessageToJSON(message models.Messageable, dir string, config *Config)
 	}
 
 	// Sanitize filename
-	filename := fmt.Sprintf("msg_%s.json", sanitizeFilename(id))
+	filename := fmt.Sprintf("msg_%s.json", export.SanitizeFilename(id))
 	filePath := filepath.Join(dir, filename)
 
 	if err := os.WriteFile(filePath, jsonData, 0644); err != nil {
@@ -767,18 +909,6 @@ func exportMessageToJSON(message models.Messageable, dir string, config *Config)
 
 	logVerbose(config.VerboseMode, "Exported message to %s", filePath)
 	return nil
-}
-
-// createExportDir creates the export directory structure: $TEMP/export/YYYY-MM-DD
-func createExportDir() (string, error) {
-	tempDir := os.TempDir()
-	dateStr := time.Now().Format("2006-01-02")
-	exportDir := filepath.Join(tempDir, "export", dateStr)
-
-	if err := os.MkdirAll(exportDir, 0755); err != nil {
-		return "", fmt.Errorf("failed to create export directory %s: %w", exportDir, err)
-	}
-	return exportDir, nil
 }
 
 // extractEmailAddress helper
@@ -802,15 +932,6 @@ func extractRecipients(recipients []models.Recipientable) []map[string]string {
 		}
 	}
 	return res
-}
-
-// sanitizeFilename helper
-func sanitizeFilename(name string) string {
-	invalid := []string{"<", ">", ":", "\"", "/", "\\", "|", "?", "*", "="}
-	for _, char := range invalid {
-		name = strings.ReplaceAll(name, char, "_")
-	}
-	return name
 }
 
 // interpretAvailability converts Microsoft Graph availability view codes to human-readable status.

--- a/internal/protocols/msgraph/utils.go
+++ b/internal/protocols/msgraph/utils.go
@@ -121,6 +121,28 @@ func validateMessageID(msgID string) error {
 	return nil
 }
 
+// validateSearchSubject validates a subject search pattern used in an OData
+// contains() filter. Single quotes are escaped (doubled) by the caller before
+// being embedded in the filter, so this only rejects empty/oversized input and
+// control characters that have no place in an email subject.
+func validateSearchSubject(subject string) error {
+	if strings.TrimSpace(subject) == "" {
+		return fmt.Errorf("subject cannot be empty")
+	}
+
+	if len(subject) > 998 {
+		return fmt.Errorf("exceeds maximum length of 998 characters")
+	}
+
+	for _, r := range subject {
+		if r < 0x20 && r != '\t' {
+			return fmt.Errorf("contains invalid control characters")
+		}
+	}
+
+	return nil
+}
+
 // enrichGraphAPIError enriches Graph API errors with additional context,
 // particularly for rate limiting scenarios. It detects rate limit errors (429)
 // and extracts the Retry-After header if available.

--- a/internal/protocols/pop3/cmd.go
+++ b/internal/protocols/pop3/cmd.go
@@ -33,6 +33,7 @@ Environment variables use the POP3 prefix (e.g. POP3HOST, POP3PORT, POP3USERNAME
 		newTestConnectCmd(v),
 		newTestAuthCmd(v),
 		newListMailCmd(v),
+		newExportMessagesCmd(v),
 	)
 
 	return cmd
@@ -175,5 +176,56 @@ Shows message count, total size, and per-message size and UIDL (if supported).`,
 
 	cmd.Flags().Int("maxmessages", 100, "Maximum messages to list (env: POP3MAXMESSAGES)")
 
+	return cmd
+}
+
+func newExportMessagesCmd(v *viper.Viper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exportmessages",
+		Short: "Search messages by Message-ID and/or Subject and export them as .eml files",
+		Long: `Authenticate to the POP3 server, fetch headers for each message via TOP,
+match against the given Message-ID and/or Subject, and export each match's
+full message (via RETR) as a .eml file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = v.BindPFlags(cmd.Flags())
+			_ = v.BindPFlags(cmd.InheritedFlags())
+
+			if err := bootstrap.LoadConfigFile(v, v.GetString("config")); err != nil {
+				return err
+			}
+
+			config := ConfigFromViper(v)
+			config.Action = ActionExportMessages
+
+			if err := validateConfiguration(config); err != nil {
+				return fmt.Errorf("validation failed: %w\n\nRun '%s --help' for usage", err, cmd.CommandPath())
+			}
+
+			ctx, cancel := bootstrap.SetupSignalContext()
+			defer cancel()
+
+			slogger, csvLogger, logErr := bootstrap.InitLoggers("pop3tool", ActionExportMessages, config.VerboseMode, config.LogLevel, config.LogFormat)
+			if logErr != nil {
+				slogger.Warn("Could not initialize file logging", "error", logErr)
+			}
+			if csvLogger != nil {
+				defer csvLogger.Close()
+			}
+
+			logger.LogInfo(slogger, "POP3 Connectivity Testing Tool started", "action", config.Action, "host", config.Host, "port", config.Port)
+
+			if err := exportMessages(ctx, config, csvLogger, slogger); err != nil {
+				logger.LogError(slogger, "Action failed", "error", err)
+				return err
+			}
+
+			logger.LogInfo(slogger, "Action completed successfully")
+			return nil
+		},
+	}
+	cmd.Flags().String("messageid", "", "Message-ID header value to search for (env: POP3MESSAGEID)")
+	cmd.Flags().String("subject", "", "Subject substring to search for (env: POP3SUBJECT)")
+	cmd.Flags().Int("count", 25, "Maximum number of matching messages to export (env: POP3COUNT)")
+	cmd.Flags().String("exportdir", "", "Directory under which to create the dated export folder; defaults to the OS temp directory (env: POP3EXPORTDIR)")
 	return cmd
 }

--- a/internal/protocols/pop3/config.go
+++ b/internal/protocols/pop3/config.go
@@ -53,13 +53,20 @@ type Config struct {
 	OutputFormat string
 	LogFormat    string  // Log file format: csv, json
 	RateLimit    float64 // Maximum requests per second (0 = unlimited)
+
+	// exportmessages configuration
+	Subject   string // Subject substring to search for
+	MessageID string // Message-ID header to search for
+	Count     int    // Maximum number of matching messages to export
+	ExportDir string // Directory under which to create the dated export folder (default: OS temp dir)
 }
 
 // Action constants
 const (
-	ActionTestConnect = "testconnect"
-	ActionTestAuth    = "testauth"
-	ActionListMail    = "listmail"
+	ActionTestConnect    = "testconnect"
+	ActionTestAuth       = "testauth"
+	ActionListMail       = "listmail"
+	ActionExportMessages = "exportmessages"
 )
 
 // NewConfig creates a new Config with default values.
@@ -80,6 +87,7 @@ func NewConfig() *Config {
 		OutputFormat: "text",
 		LogFormat:    "csv",
 		RateLimit:    0,
+		Count:        25,
 	}
 }
 
@@ -150,6 +158,10 @@ func BindEnvs(v *viper.Viper) {
 		"logformat":   "POP3LOGFORMAT",
 		"ratelimit":   "POP3RATELIMIT",
 		"maxmessages": "POP3MAXMESSAGES",
+		"subject":     "POP3SUBJECT",
+		"messageid":   "POP3MESSAGEID",
+		"count":       "POP3COUNT",
+		"exportdir":   "POP3EXPORTDIR",
 	}
 	for key, env := range bindings {
 		_ = v.BindEnv(key, env)
@@ -211,6 +223,11 @@ func ConfigFromViper(v *viper.Viper) *Config {
 		logFormat = defaults.LogFormat
 	}
 
+	count := v.GetInt("count")
+	if count <= 0 {
+		count = defaults.Count
+	}
+
 	return &Config{
 		Host:           v.GetString("host"),
 		Port:           port,
@@ -237,13 +254,17 @@ func ConfigFromViper(v *viper.Viper) *Config {
 		OutputFormat:   outputFormat,
 		LogFormat:      logFormat,
 		RateLimit:      v.GetFloat64("ratelimit"),
+		Subject:        v.GetString("subject"),
+		MessageID:      v.GetString("messageid"),
+		Count:          count,
+		ExportDir:      v.GetString("exportdir"),
 	}
 }
 
 // validateConfiguration validates the configuration.
 func validateConfiguration(config *Config) error {
 	// Validate action
-	validActions := []string{ActionTestConnect, ActionTestAuth, ActionListMail}
+	validActions := []string{ActionTestConnect, ActionTestAuth, ActionListMail, ActionExportMessages}
 	valid := false
 	for _, a := range validActions {
 		if config.Action == a {
@@ -318,7 +339,7 @@ func validateConfiguration(config *Config) error {
 
 	// Action-specific validation
 	switch config.Action {
-	case ActionTestAuth, ActionListMail:
+	case ActionTestAuth, ActionListMail, ActionExportMessages:
 		if config.Username == "" {
 			return fmt.Errorf("%s requires --username", config.Action)
 		}
@@ -335,6 +356,13 @@ func validateConfiguration(config *Config) error {
 			}
 		} else if config.Password == "" {
 			return fmt.Errorf("%s requires --password (or --accesstoken for XOAUTH2)", config.Action)
+		}
+	}
+
+	// Validate exportmessages-specific requirements
+	if config.Action == ActionExportMessages {
+		if config.MessageID == "" && strings.TrimSpace(config.Subject) == "" {
+			return fmt.Errorf("exportmessages action requires --messageid and/or --subject parameter")
 		}
 	}
 

--- a/internal/protocols/pop3/exportmessages.go
+++ b/internal/protocols/pop3/exportmessages.go
@@ -1,0 +1,179 @@
+package pop3
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/mail"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ziembor/gomailtesttool/internal/common/export"
+	"github.com/ziembor/gomailtesttool/internal/common/logger"
+)
+
+// exportMessages fetches headers for each message via TOP, matches them
+// against config.MessageID and/or config.Subject, and exports matches (via
+// RETR) as raw .eml (RFC822) files.
+func exportMessages(ctx context.Context, config *Config, csvLogger logger.Logger, slogLogger *slog.Logger) error {
+	fmt.Printf("Searching mailbox on %s:%d for matching messages...\n", config.Host, config.Port)
+
+	columns := []string{"Action", "Status", "Server", "Port", "Message_Number", "Subject", "Filename", "Error"}
+	if shouldWrite, _ := csvLogger.ShouldWriteHeader(); shouldWrite {
+		if err := csvLogger.WriteHeader(columns); err != nil {
+			logger.LogError(slogLogger, "Failed to write CSV header", "error", err)
+		}
+	}
+
+	client := NewPOP3Client(config)
+
+	if err := client.Connect(ctx); err != nil {
+		logger.LogError(slogLogger, "Connection failed", "error", err, "host", config.Host, "port", config.Port)
+		writeExportRow(csvLogger, slogLogger, config, false, "", "", "", err.Error())
+		return fmt.Errorf("connection failed: %w", err)
+	}
+	defer func() { _ = client.Quit() }()
+
+	fmt.Printf("✓ Connected to %s:%d\n", config.Host, config.Port)
+
+	if config.StartTLS && client.GetTLSState() == nil {
+		fmt.Println("Upgrading to TLS via STLS...")
+		if err := client.StartTLS(nil); err != nil {
+			logger.LogError(slogLogger, "STLS upgrade failed", "error", err)
+			writeExportRow(csvLogger, slogLogger, config, false, "", "", "", fmt.Sprintf("STLS failed: %v", err))
+			return fmt.Errorf("STLS failed: %w", err)
+		}
+		fmt.Println("✓ TLS upgrade successful")
+	}
+
+	caps, _ := client.Capabilities(ctx)
+
+	authMethod := config.AuthMethod
+	if strings.EqualFold(authMethod, "auto") {
+		if config.AccessToken != "" {
+			if caps != nil && caps.SupportsXOAUTH2() {
+				authMethod = "XOAUTH2"
+			} else {
+				authMethod = "USER"
+			}
+		} else {
+			authMethod = "USER"
+		}
+	}
+
+	var authErr error
+	if config.AccessToken != "" && strings.EqualFold(authMethod, "XOAUTH2") {
+		authErr = client.Auth(ctx, config.Username, "", config.AccessToken)
+	} else {
+		authErr = client.Auth(ctx, config.Username, config.Password, "")
+	}
+	if authErr != nil {
+		logger.LogError(slogLogger, "Authentication failed", "error", authErr, "username", maskUsername(config.Username))
+		writeExportRow(csvLogger, slogLogger, config, false, "", "", "", fmt.Sprintf("Auth failed: %v", authErr))
+		return fmt.Errorf("authentication failed: %w", authErr)
+	}
+	fmt.Println("✓ Authentication successful")
+
+	messages, err := client.List(ctx)
+	if err != nil {
+		logger.LogError(slogLogger, "LIST command failed", "error", err)
+		writeExportRow(csvLogger, slogLogger, config, false, "", "", "", fmt.Sprintf("LIST failed: %v", err))
+		return fmt.Errorf("LIST failed: %w", err)
+	}
+
+	exportDir, err := export.CreateExportDir(config.ExportDir)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Export directory: %s\n", exportDir)
+
+	wantMessageID := strings.Trim(config.MessageID, "<>")
+	wantSubject := strings.ToLower(config.Subject)
+
+	successCount := 0
+	for _, m := range messages {
+		if successCount >= config.Count {
+			break
+		}
+
+		header, err := client.Top(ctx, m.Number, 0)
+		if err != nil {
+			logger.LogError(slogLogger, "TOP failed", "error", err, "msgnum", m.Number)
+			continue
+		}
+
+		parsed, err := mail.ReadMessage(strings.NewReader(string(header) + "\r\n"))
+		if err != nil {
+			logger.LogError(slogLogger, "Failed to parse message headers", "error", err, "msgnum", m.Number)
+			continue
+		}
+
+		subject := parsed.Header.Get("Subject")
+		messageID := strings.Trim(parsed.Header.Get("Message-Id"), "<>")
+
+		if !matchesCriteria(messageID, subject, wantMessageID, wantSubject) {
+			continue
+		}
+
+		body, err := client.Retr(ctx, m.Number)
+		if err != nil {
+			logger.LogError(slogLogger, "RETR failed", "error", err, "msgnum", m.Number)
+			writeExportRow(csvLogger, slogLogger, config, false, fmt.Sprintf("%d", m.Number), subject, "", err.Error())
+			continue
+		}
+
+		name := messageID
+		if name == "" {
+			name = fmt.Sprintf("msg_%d", m.Number)
+		}
+		filename := fmt.Sprintf("msg_%s.eml", export.SanitizeFilename(name))
+		filePath := filepath.Join(exportDir, filename)
+		if err := os.WriteFile(filePath, body, 0644); err != nil {
+			logger.LogError(slogLogger, "Failed to write EML file", "error", err, "msgnum", m.Number)
+			writeExportRow(csvLogger, slogLogger, config, false, fmt.Sprintf("%d", m.Number), subject, "", err.Error())
+			continue
+		}
+
+		successCount++
+		fmt.Printf("Successfully exported message %d -> %s\n", m.Number, filePath)
+		writeExportRow(csvLogger, slogLogger, config, true, fmt.Sprintf("%d", m.Number), subject, filePath, "")
+	}
+
+	if successCount == 0 {
+		fmt.Println("No messages found matching the given criteria.")
+		writeExportRow(csvLogger, slogLogger, config, true, "", "", "", "No messages found (0 messages)")
+		return nil
+	}
+
+	fmt.Printf("Successfully exported %d message(s).\n", successCount)
+	return nil
+}
+
+// matchesCriteria reports whether a message's Message-Id/Subject headers
+// satisfy the search criteria. At least one of wantMessageID/wantSubject is
+// non-empty (enforced by validateConfiguration); both given criteria must
+// match if both are provided.
+func matchesCriteria(messageID, subject, wantMessageID, wantSubject string) bool {
+	if wantMessageID != "" && messageID != wantMessageID {
+		return false
+	}
+	if wantSubject != "" && !strings.Contains(strings.ToLower(subject), wantSubject) {
+		return false
+	}
+	return true
+}
+
+// writeExportRow writes a single CSV row for the exportmessages action.
+func writeExportRow(csvLogger logger.Logger, slogLogger *slog.Logger, config *Config, success bool, msgNum, subject, filename, errStr string) {
+	status := "FAILURE"
+	if success {
+		status = "SUCCESS"
+	}
+	if logErr := csvLogger.WriteRow([]string{
+		ActionExportMessages, status, config.Host, fmt.Sprintf("%d", config.Port),
+		msgNum, subject, filename, errStr,
+	}); logErr != nil {
+		logger.LogError(slogLogger, "Failed to write CSV row", "error", logErr)
+	}
+}

--- a/internal/protocols/pop3/pop3_client.go
+++ b/internal/protocols/pop3/pop3_client.go
@@ -348,6 +348,53 @@ func (c *POP3Client) UIDL(ctx context.Context) ([]protocol.MessageInfo, error) {
 	return protocol.ParseUIDLResponse(resp)
 }
 
+// Top retrieves the headers and the first `lines` lines of the body for the
+// given message number. Pass lines=0 to retrieve only the headers.
+func (c *POP3Client) Top(ctx context.Context, msgNum, lines int) ([]byte, error) {
+	if c.limiter != nil {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limit wait: %w", err)
+		}
+	}
+
+	if _, err := c.conn.Write([]byte(protocol.TOP(msgNum, lines))); err != nil {
+		return nil, fmt.Errorf("failed to send TOP: %w", err)
+	}
+
+	resp, err := protocol.ReadMultilineResponse(c.reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read TOP response: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("TOP failed: %s", resp.Message)
+	}
+
+	return []byte(strings.Join(resp.Lines, "\r\n")), nil
+}
+
+// Retr retrieves the full content of the given message number.
+func (c *POP3Client) Retr(ctx context.Context, msgNum int) ([]byte, error) {
+	if c.limiter != nil {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limit wait: %w", err)
+		}
+	}
+
+	if _, err := c.conn.Write([]byte(protocol.RETR(msgNum))); err != nil {
+		return nil, fmt.Errorf("failed to send RETR: %w", err)
+	}
+
+	resp, err := protocol.ReadMultilineResponse(c.reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RETR response: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("RETR failed: %s", resp.Message)
+	}
+
+	return []byte(strings.Join(resp.Lines, "\r\n")), nil
+}
+
 // Quit sends the QUIT command and closes the connection.
 func (c *POP3Client) Quit() error {
 	if c.conn == nil {


### PR DESCRIPTION
## Summary

This PR adds a new `exportmessages` action across three email protocols (IMAP, POP3, and MS Graph) that allows users to search for messages by Internet Message-ID and/or subject substring, then export matching messages as raw RFC822 `.eml` files.

## Key Changes

### New Features
- **IMAP**: Added `exportmessages` command that uses SEARCH to find messages by Message-ID/Subject headers and exports them via FETCH
- **POP3**: Added `exportmessages` command that uses TOP to fetch headers for matching criteria and RETR to export full messages
- **MS Graph**: Added `exportmessages` command that uses OData filters to search by internetMessageId and subject, then downloads raw MIME content

### Shared Infrastructure
- Created new `internal/common/export` package with:
  - `CreateExportDir()`: Generates dated export directories (`<baseDir>/export/YYYY-MM-DD/`)
  - `SanitizeFilename()`: Sanitizes filenames for filesystem safety
- Refactored MS Graph's existing `createExportDir()` and `sanitizeFilename()` functions to use the shared package

### Protocol-Specific Implementations
- **IMAP** (`internal/protocols/imap/`):
  - Added `SelectMailbox()`, `SearchMessages()`, and `FetchRFC822()` client methods
  - New `exportmessages.go` with search/export logic and CSV logging
  - Updated config to support `messageid`, `subject`, `mailbox`, `count`, and `exportdir` parameters

- **POP3** (`internal/protocols/pop3/`):
  - Added `Top()` and `Retr()` client methods for header/body retrieval
  - New `exportmessages.go` with header matching and export logic
  - Updated config to support `messageid`, `subject`, `count`, and `exportdir` parameters

- **MS Graph** (`internal/protocols/msgraph/`):
  - Added `exportMessages()` and `exportMessageToEML()` handlers
  - New JMAP protocol helpers: `NewEmailGetRequest()`, `ParseEmailGetResponse()`, and `BuildEmailSearchFilter()`
  - Updated config to support `exportdir` parameter
  - Added `validateSearchSubject()` utility for OData filter validation

### Documentation
- Updated `docs/protocols/imap.md`, `docs/protocols/pop3.md`, and `docs/protocols/msgraph.md` with usage examples and flag documentation for the new `exportmessages` action

## Implementation Details

- **Search Criteria**: All implementations support searching by Message-ID (exact match) and/or Subject (substring match). At least one criterion must be provided.
- **Export Format**: Messages are exported as raw RFC822 `.eml` files with sanitized filenames based on Message-ID or message number/UID
- **CSV Logging**: Each protocol logs export results to CSV with action status, server details, and error information
- **Rate Limiting**: IMAP and POP3 implementations respect configured rate limits during API calls
- **OData Security**: MS Graph implementation escapes single quotes in search filters for defense-in-depth protection

https://claude.ai/code/session_01XqmZvaRnk6rQ2whp5DaBb5